### PR TITLE
Add buyer listing experience and seller workspace

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
-# Mazad.com
+# Mazad.com MVP Workspace
+
+This repository contains the documentation, data catalogs, and Next.js scaffold for the Mazad.com marketplace MVP. It follows the operating modes described in `agent_md_mazad.md` and ships artifacts for product, design, and engineering stakeholders.
+
+## Repository Structure
+- `docs/` – Planning artifacts including category tree, vehicles taxonomy guide, user stories, IA spec, and roadmap.
+- `data/` – JSON/CSV catalogs for categories, filters, vehicles, and localization keys.
+- `schemas/` – JSON Schemas that validate category, filter, and vehicle datasets.
+- `scripts/` – Utility scripts for generating vehicles JSON and validating data assets.
+- `app/` – Next.js (App Router) scaffold with TypeScript, Tailwind CSS, and sample pages/components.
+
+## Getting Started
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+2. **Generate vehicles JSON from CSV sources**
+   ```bash
+   npm run generate:vehicles
+   ```
+3. **Validate JSON assets against schemas**
+   ```bash
+   npm run validate
+   ```
+4. **Run the development server**
+   ```bash
+   npm run dev
+   ```
+   Visit `http://localhost:3000` to explore the scaffold (category browse, filters mock, vehicles taxonomy pages).
+
+## Available Scripts
+- `npm run generate:vehicles` – Reads CSV files in `data/vehicles/` and writes `vehicles.json`.
+- `npm run validate` – Validates `data/categories.json`, `data/filters.json`, and `data/vehicles/vehicles.json` against schemas.
+- `npm run dev` – Starts Next.js in development mode.
+- `npm run build` – Builds production output.
+- `npm run lint` – Runs ESLint using Next.js defaults.
+
+## Data Workflow
+1. Update CSV catalogs (`brands.csv`, `models.csv`, `trims.csv`).
+2. Run `npm run generate:vehicles` to rebuild `vehicles.json`.
+3. Commit CSV and JSON changes together.
+4. Execute `npm run validate` before submitting PRs.
+
+## Documentation Index
+- [Overview](docs/00-overview.md)
+- [Category Tree](docs/10-category-tree.md)
+- [Vehicles Taxonomy](docs/20-vehicles-taxonomy.md)
+- [Buyer Stories](docs/30-user-stories-buyer.md)
+- [Seller Stories](docs/31-user-stories-seller.md)
+- [Acceptance Criteria Matrix](docs/32-acceptance-criteria.md)
+- [IA & Menu Spec](docs/40-ia-menu-spec.md)
+- [Roadmap](docs/50-roadmap-mvp1-3.md)
+
+## Linting & Formatting
+The project relies on ESLint (Next.js configuration) and Tailwind CSS for styling. Prettier is not included; format using your editor defaults.
+
+## License
+All generated assets are work-for-hire for Mazad.com. See `agent_md_mazad.md` for additional constraints.

--- a/app/categories/[slug]/CategoryPageContent.tsx
+++ b/app/categories/[slug]/CategoryPageContent.tsx
@@ -1,0 +1,355 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import FilterPanel, { type FilterState } from '@/app/components/FilterPanel';
+import ListingCard from '@/app/components/ListingCard';
+import type { CategoryFilter, CategoryNode, FilterOption, ListingSummary } from '@/app/types';
+import { trackEvent } from '@/app/lib/analytics';
+
+type CategoryPageContentProps = {
+  category: CategoryNode;
+  filters: CategoryFilter[];
+  subcategories: CategoryNode[];
+  listings: ListingSummary[];
+  focusSlug?: string;
+  focusedSubcategory?: CategoryNode;
+};
+
+const parseNumber = (value?: string) => {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const areStatesEqual = (a: FilterState, b: FilterState) => {
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const key of keys) {
+    if (a[key] !== b[key]) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const matchesListingFilters = (listing: ListingSummary, state: FilterState) => {
+  if (state.condition && listing.condition !== state.condition) {
+    return false;
+  }
+
+  if (state.brand && listing.brandSlug) {
+    if (listing.brandSlug !== state.brand) {
+      return false;
+    }
+  } else if (state.brand) {
+    return false;
+  }
+
+  if (state.model && listing.modelSlug) {
+    if (listing.modelSlug !== state.model) {
+      return false;
+    }
+  } else if (state.model) {
+    return false;
+  }
+
+  if (state.trim && listing.trim) {
+    if (listing.trim !== state.trim) {
+      return false;
+    }
+  } else if (state.trim) {
+    return false;
+  }
+
+  if (state.city && listing.citySlug) {
+    if (listing.citySlug !== state.city) {
+      return false;
+    }
+  } else if (state.city) {
+    return false;
+  }
+
+  if (state.accident_history) {
+    if (!listing.accidentHistory || listing.accidentHistory !== state.accident_history) {
+      return false;
+    }
+  }
+
+  if (state.warranty_status) {
+    if (!listing.warrantyStatus || listing.warrantyStatus !== state.warranty_status) {
+      return false;
+    }
+  }
+
+  const yearMin = parseNumber(state.year_min);
+  if (yearMin !== undefined) {
+    if (!listing.year || listing.year < yearMin) {
+      return false;
+    }
+  }
+
+  const yearMax = parseNumber(state.year_max);
+  if (yearMax !== undefined) {
+    if (!listing.year || listing.year > yearMax) {
+      return false;
+    }
+  }
+
+  const mileageMin = parseNumber(state.mileage_min);
+  if (mileageMin !== undefined) {
+    if (listing.mileageKm === undefined || listing.mileageKm < mileageMin) {
+      return false;
+    }
+  }
+
+  const mileageMax = parseNumber(state.mileage_max);
+  if (mileageMax !== undefined) {
+    if (listing.mileageKm === undefined || listing.mileageKm > mileageMax) {
+      return false;
+    }
+  }
+
+  const owners = parseNumber(state.owners);
+  if (owners !== undefined) {
+    if (listing.owners === undefined || listing.owners > owners) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const normalizeOption = (option: FilterOption) =>
+  typeof option === 'string' ? { value: option, label: option } : option;
+
+const describeFilterValue = (
+  key: string,
+  value: string,
+  filtersByKey: Map<string, CategoryFilter>
+) => {
+  const rangeMatch = key.match(/(.+)_(min|max)$/);
+  const lookupKey = rangeMatch ? rangeMatch[1] : key;
+  const filter = filtersByKey.get(lookupKey);
+  const label = filter ? filter.key.replace(/_/g, ' ') : lookupKey.replace(/_/g, ' ');
+
+  if (rangeMatch) {
+    const suffix = rangeMatch[2] === 'min' ? '≥' : '≤';
+    return `${label} ${suffix} ${value}`;
+  }
+
+  if (filter?.options) {
+    const normalizedOptions = filter.options.map(normalizeOption);
+    const match = normalizedOptions.find((option) => option.value === value);
+    if (match) {
+      return `${label}: ${match.label}`;
+    }
+  }
+
+  return `${label}: ${value.replace(/_/g, ' ')}`;
+};
+
+const CategoryPageContent = ({
+  category,
+  filters,
+  subcategories,
+  listings,
+  focusSlug,
+  focusedSubcategory
+}: CategoryPageContentProps) => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const filterKeys = useMemo(() => {
+    const keys = new Set<string>();
+    filters.forEach((filter) => {
+      keys.add(filter.key);
+      if (filter.type === 'range') {
+        keys.add(`${filter.key}_min`);
+        keys.add(`${filter.key}_max`);
+      }
+    });
+    return keys;
+  }, [filters]);
+
+  const filterDefaults = useMemo(() => {
+    const defaults: FilterState = {};
+    filters.forEach((filter) => {
+      if (filter.default !== undefined && filter.default !== null) {
+        defaults[filter.key] = String(filter.default);
+      }
+    });
+    return defaults;
+  }, [filters]);
+
+  const initialFromParams = useMemo(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    const state: FilterState = {};
+    filterKeys.forEach((key) => {
+      const value = params.get(key);
+      if (value) {
+        state[key] = value;
+      }
+    });
+    return state;
+  }, [filterKeys, searchParams]);
+
+  const initialFilterState = useMemo(
+    () => ({ ...filterDefaults, ...initialFromParams }),
+    [filterDefaults, initialFromParams]
+  );
+
+  const [filterState, setFilterState] = useState<FilterState>(initialFilterState);
+
+  useEffect(() => {
+    setFilterState((prev) => (areStatesEqual(prev, initialFilterState) ? prev : initialFilterState));
+  }, [initialFilterState]);
+
+  const filtersByKey = useMemo(() => {
+    const map = new Map<string, CategoryFilter>();
+    filters.forEach((filter) => {
+      map.set(filter.key, filter);
+    });
+    return map;
+  }, [filters]);
+
+  const handleFilterStateChange = useCallback(
+    (next: FilterState) => {
+      setFilterState(next);
+      const params = new URLSearchParams(searchParams.toString());
+      filterKeys.forEach((key) => {
+        params.delete(key);
+      });
+      Object.entries(next).forEach(([key, value]) => {
+        if (value) {
+          params.set(key, value);
+        }
+      });
+      const queryString = params.toString();
+      const target = queryString ? `${pathname}?${queryString}` : pathname;
+      router.replace(target, { scroll: false });
+    },
+    [filterKeys, pathname, router, searchParams]
+  );
+
+  const filteredListings = useMemo(
+    () => listings.filter((listing) => matchesListingFilters(listing, filterState)),
+    [listings, filterState]
+  );
+
+  const activeFilters = useMemo(
+    () => Object.entries(filterState).filter(([, value]) => value && value.length > 0),
+    [filterState]
+  );
+
+  const breadcrumbItems = useMemo(() => {
+    const items = [
+      { label: 'Home', href: '/' },
+      { label: 'Categories', href: '/categories' },
+      { label: category.label, href: `/categories/${category.slug}` }
+    ];
+    if (focusedSubcategory) {
+      items.push({
+        label: focusedSubcategory.label,
+        href: `/categories/${category.slug}?focus=${focusedSubcategory.slug}`
+      });
+    }
+    return items;
+  }, [category.label, category.slug, focusedSubcategory]);
+
+  const activeFocus = searchParams.get('focus') ?? focusSlug ?? undefined;
+
+  useEffect(() => {
+    trackEvent('category_view', {
+      categorySlug: category.slug,
+      focusSlug: activeFocus ?? null
+    });
+  }, [activeFocus, category.slug]);
+
+  return (
+    <div className="space-y-6">
+      <nav aria-label="Breadcrumb" className="text-sm text-slate-500">
+        <ol className="flex flex-wrap items-center gap-2">
+          {breadcrumbItems.map((item, index) => (
+            <li key={item.href} className="flex items-center gap-2">
+              {index > 0 && <span className="text-slate-400">/</span>}
+              <Link href={item.href} className="hover:text-brand-primary">
+                {item.label}
+              </Link>
+            </li>
+          ))}
+        </ol>
+      </nav>
+      <div className="grid gap-8 lg:grid-cols-[2fr,1fr]">
+        <section className="space-y-6">
+          <header className="space-y-3">
+            <h1 className="text-3xl font-bold text-brand-primary">{category.label}</h1>
+            {category.description && <p className="text-slate-600">{category.description}</p>}
+            {focusedSubcategory && (
+              <div className="rounded border border-brand-accent bg-orange-50 px-4 py-3 text-sm text-brand-primary">
+                Highlighted focus: {focusedSubcategory.label}
+              </div>
+            )}
+          </header>
+          {subcategories.length > 0 && (
+            <div className="space-y-2">
+              <h2 className="text-lg font-semibold text-brand-primary">Subcategories</h2>
+              <div className="flex flex-wrap gap-2">
+                {subcategories.map((child) => (
+                  <Link
+                    key={child.slug}
+                    href={`/categories/${category.slug}?focus=${child.slug}`}
+                    className={`rounded-full border px-3 py-1 text-sm transition ${
+                      child.slug === activeFocus
+                        ? 'border-brand-accent bg-brand-accent/10 text-brand-primary'
+                        : 'border-slate-200 text-slate-600 hover:border-brand-accent hover:text-brand-primary'
+                    }`}
+                  >
+                    {child.label}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
+          <div className="space-y-3">
+            <div className="flex flex-col gap-2 border-b border-slate-200 pb-3 sm:flex-row sm:items-center sm:justify-between">
+              <h2 className="text-xl font-semibold text-brand-primary">Listings</h2>
+              <p className="text-sm text-slate-500">
+                Showing {filteredListings.length} of {listings.length} results
+              </p>
+            </div>
+            {activeFilters.length > 0 && (
+              <div className="flex flex-wrap gap-2 text-xs">
+                {activeFilters.map(([key, value]) => (
+                  <span
+                    key={`${key}-${value}`}
+                    className="rounded-full bg-slate-100 px-3 py-1 font-medium text-slate-600"
+                  >
+                    {describeFilterValue(key, value, filtersByKey)}
+                  </span>
+                ))}
+              </div>
+            )}
+            {filteredListings.length > 0 ? (
+              <div className="grid gap-6 md:grid-cols-2">
+                {filteredListings.map((listing) => (
+                  <ListingCard key={listing.id} listing={listing} />
+                ))}
+              </div>
+            ) : (
+              <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-6 text-sm text-slate-600">
+                No mock listings match the selected filters yet. Adjust your filters to explore other results.
+              </div>
+            )}
+          </div>
+        </section>
+        <FilterPanel title="Filter" filters={filters} initialState={filterState} onStateChange={handleFilterStateChange} />
+      </div>
+    </div>
+  );
+};
+
+export default CategoryPageContent;

--- a/app/categories/[slug]/page.tsx
+++ b/app/categories/[slug]/page.tsx
@@ -1,0 +1,43 @@
+import { notFound } from 'next/navigation';
+import categoriesJson from '@/data/categories.json';
+import filtersJson from '@/data/filters.json';
+import listingsJson from '@/data/listings.json';
+import type { CategoriesData, FiltersData, ListingsData } from '@/app/types';
+import CategoryPageContent from './CategoryPageContent';
+
+const categoriesData = categoriesJson as CategoriesData;
+const filtersData = filtersJson as FiltersData;
+const listingsData = listingsJson as ListingsData;
+
+const findCategory = (slug: string) => categoriesData.categories.find((category) => category.slug === slug);
+
+export default function CategoryPage({
+  params,
+  searchParams
+}: {
+  params: { slug: string };
+  searchParams: { focus?: string };
+}) {
+  const category = findCategory(params.slug);
+
+  if (!category) {
+    notFound();
+  }
+
+  const categoryFilters = filtersData.filters[category.slug] ?? [];
+  const subcategories = category.children ?? [];
+  const focusSlug = searchParams?.focus;
+  const focusedSubcategory = subcategories.find((child) => child.slug === focusSlug);
+  const categoryListings = listingsData.listings.filter((listing) => listing.categorySlug === category.slug);
+
+  return (
+    <CategoryPageContent
+      category={category}
+      filters={categoryFilters}
+      subcategories={subcategories}
+      listings={categoryListings}
+      focusSlug={focusSlug}
+      focusedSubcategory={focusedSubcategory}
+    />
+  );
+}

--- a/app/categories/cars/[brand]/[model]/page.tsx
+++ b/app/categories/cars/[brand]/[model]/page.tsx
@@ -1,0 +1,71 @@
+import { notFound } from 'next/navigation';
+import vehiclesJson from '@/data/vehicles/vehicles.json';
+import filtersJson from '@/data/filters.json';
+import type { VehiclesData, FiltersData } from '@/app/types';
+import FilterPanel from '@/app/components/FilterPanel';
+
+const vehiclesData = vehiclesJson as VehiclesData;
+const filtersData = filtersJson as FiltersData;
+
+const findModel = (brandSlug: string, modelSlug: string) => {
+  const brand = vehiclesData.brands.find((entry) => entry.brand === brandSlug);
+  if (!brand) {
+    return undefined;
+  }
+  const model = brand.models.find((entry) => entry.model === modelSlug);
+  if (!model) {
+    return undefined;
+  }
+  return { brand, model };
+};
+
+export default function VehicleModelPage({ params }: { params: { brand: string; model: string } }) {
+  const lookup = findModel(params.brand, params.model);
+
+  if (!lookup) {
+    notFound();
+  }
+
+  const { brand, model } = lookup;
+  const vehicleFilters = filtersData.filters['vehicles'] ?? [];
+
+  return (
+    <div className="grid gap-8 lg:grid-cols-[2fr,1fr]">
+      <section className="space-y-6">
+        <header className="space-y-2">
+          <p className="text-sm uppercase tracking-wide text-slate-500">{brand.label}</p>
+          <h1 className="text-3xl font-bold text-brand-primary">{model.label}</h1>
+          <p className="text-slate-600">
+            {model.bodyType} · {model.year_min} – {model.year_max}
+          </p>
+        </header>
+        <div className="space-y-4">
+          <h2 className="text-xl font-semibold text-brand-primary">Available trims</h2>
+          <div className="grid gap-4 md:grid-cols-2">
+            {model.trims.map((trim) => (
+              <article key={trim.trim} className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+                <h3 className="text-lg font-semibold text-brand-primary">{trim.label}</h3>
+                <ul className="mt-2 space-y-1 text-sm text-slate-600">
+                  {trim.engine && <li>Engine: {trim.engine}</li>}
+                  {trim.drivetrain && <li>Drivetrain: {trim.drivetrain}</li>}
+                  {trim.transmission && <li>Transmission: {trim.transmission}</li>}
+                  {trim.fuel && <li>Fuel: {trim.fuel}</li>}
+                  <li>Years: {trim.years.join(', ')}</li>
+                </ul>
+              </article>
+            ))}
+          </div>
+        </div>
+        <div className="space-y-2 rounded-lg border border-dashed border-brand-accent bg-orange-50 p-5 text-sm text-brand-primary">
+          <h2 className="text-lg font-semibold">Used vehicle disclosure checklist</h2>
+          <ul className="mt-2 list-disc space-y-1 pl-5">
+            {model.condition.usedOnlyAttributes.map((attribute) => (
+              <li key={attribute.key}>{attribute.label}</li>
+            ))}
+          </ul>
+        </div>
+      </section>
+      <FilterPanel title="Vehicle filters" filters={vehicleFilters} />
+    </div>
+  );
+}

--- a/app/categories/cars/[brand]/page.tsx
+++ b/app/categories/cars/[brand]/page.tsx
@@ -1,0 +1,50 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import vehiclesJson from '@/data/vehicles/vehicles.json';
+import type { VehiclesData } from '@/app/types';
+
+const vehiclesData = vehiclesJson as VehiclesData;
+
+const findBrand = (brandSlug: string) =>
+  vehiclesData.brands.find((brand) => brand.brand === brandSlug);
+
+export default function BrandPage({ params }: { params: { brand: string } }) {
+  const brand = findBrand(params.brand);
+
+  if (!brand) {
+    notFound();
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold text-brand-primary">{brand.label} models</h1>
+        <p className="text-slate-600">Origin: {brand.origin} · Popular in KSA: {brand.popularInKsa ? 'Yes' : 'No'}</p>
+      </header>
+      <div className="grid gap-6 md:grid-cols-2">
+        {brand.models.map((model) => (
+          <article key={model.model} className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="text-xl font-semibold text-brand-primary">{model.label}</h2>
+            <p className="mt-1 text-sm text-slate-600">
+              {model.bodyType} · {model.year_min} – {model.year_max}
+            </p>
+            <div className="mt-3 text-xs text-slate-500">
+              Condition options: {model.condition.options.join(', ')}
+            </div>
+            <ul className="mt-4 space-y-1 text-sm text-slate-600">
+              {model.trims.slice(0, 3).map((trim) => (
+                <li key={trim.trim}>{trim.label}</li>
+              ))}
+            </ul>
+            <Link
+              href={`/categories/cars/${brand.brand}/${model.model}`}
+              className="mt-4 inline-flex w-full justify-center rounded bg-brand-accent px-3 py-2 text-sm font-semibold text-white"
+            >
+              View trims
+            </Link>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/categories/cars/page.tsx
+++ b/app/categories/cars/page.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link';
+import vehiclesJson from '@/data/vehicles/vehicles.json';
+import type { VehiclesData } from '@/app/types';
+
+const vehiclesData = vehiclesJson as VehiclesData;
+
+export default function CarsCategoryPage() {
+  return (
+    <div className="space-y-6">
+      <header className="space-y-3">
+        <h1 className="text-3xl font-bold text-brand-primary">Cars marketplace</h1>
+        <p className="text-slate-600">
+          Drill into brand → model → trim flows powered by Mazad.com\'s vehicles taxonomy and condition schema.
+        </p>
+      </header>
+      <div className="grid gap-6 md:grid-cols-3">
+        {vehiclesData.brands.map((brand) => (
+          <article key={brand.brand} className="flex h-full flex-col rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+            <div className="space-y-2">
+              <h2 className="text-xl font-semibold text-brand-primary">{brand.label}</h2>
+              <p className="text-sm text-slate-600">Origin: {brand.origin}</p>
+              {brand.popularInKsa && <span className="text-xs font-semibold uppercase text-brand-accent">Top in KSA</span>}
+            </div>
+            <ul className="mt-4 space-y-1 text-sm text-slate-600">
+              {brand.models.slice(0, 3).map((model) => (
+                <li key={model.model}>{model.label}</li>
+              ))}
+            </ul>
+            <div className="mt-auto pt-4">
+              <Link
+                href={`/categories/cars/${brand.brand}`}
+                className="inline-flex w-full justify-center rounded bg-brand-accent px-3 py-2 text-sm font-semibold text-white"
+              >
+                View models
+              </Link>
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/categories/page.tsx
+++ b/app/categories/page.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link';
+import categoriesJson from '@/data/categories.json';
+import type { CategoriesData } from '@/app/types';
+
+const categoriesData = categoriesJson as CategoriesData;
+
+export default function CategoriesIndexPage() {
+  return (
+    <div className="space-y-6">
+      <header className="space-y-3">
+        <h1 className="text-3xl font-bold text-brand-primary">All categories</h1>
+        <p className="text-slate-600">
+          Navigate across Mazad.com\'s marketplace verticals. Each category inherits structured filters and localized taxonomy.
+        </p>
+      </header>
+      <div className="grid gap-6 md:grid-cols-3">
+        {categoriesData.categories.map((category) => (
+          <article key={category.slug} className="flex h-full flex-col justify-between rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+            <div className="space-y-3">
+              <h2 className="text-xl font-semibold text-brand-primary">{category.label}</h2>
+              <p className="text-sm text-slate-600">{category.description}</p>
+              {category.featuredFilters && category.featuredFilters.length > 0 && (
+                <div className="text-xs text-slate-500">
+                  <span className="font-medium text-slate-700">Key filters:</span> {category.featuredFilters.join(', ')}
+                </div>
+              )}
+            </div>
+            <div className="mt-6">
+              <Link
+                href={`/categories/${category.slug}`}
+                className="inline-flex w-full justify-center rounded bg-brand-accent px-3 py-2 text-sm font-semibold text-white"
+              >
+                Explore {category.label}
+              </Link>
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/components/CategoryMenu.tsx
+++ b/app/components/CategoryMenu.tsx
@@ -1,0 +1,55 @@
+import Link from 'next/link';
+import type { CategoryNode } from '../types';
+
+type CategoryMenuProps = {
+  categories: CategoryNode[];
+};
+
+const buildHref = (slug: string, parentSlug?: string) => {
+  if (slug === 'cars') {
+    return '/categories/cars';
+  }
+  if (parentSlug) {
+    return `/categories/${parentSlug}?focus=${slug}`;
+  }
+  return `/categories/${slug}`;
+};
+
+const CategoryMenu = ({ categories }: CategoryMenuProps) => (
+  <nav aria-label="Category menu" className="rounded-lg bg-white p-4 shadow-sm">
+    <ul className="grid gap-4 md:grid-cols-3">
+      {categories.map((category) => (
+        <li key={category.slug} className="rounded border border-slate-200 p-4">
+          <h3 className="text-lg font-semibold text-brand-primary">{category.label}</h3>
+          {category.description && (
+            <p className="mt-2 text-sm text-slate-600">{category.description}</p>
+          )}
+          <Link
+            href={buildHref(category.slug)}
+            className="mt-4 inline-block rounded bg-brand-accent px-3 py-1 text-sm font-medium text-white"
+          >
+            Browse
+          </Link>
+          {category.children && category.children.length > 0 && (
+            <details className="mt-4">
+              <summary className="cursor-pointer text-sm font-semibold text-slate-700">
+                Subcategories
+              </summary>
+              <ul className="mt-2 space-y-1 text-sm text-slate-600">
+                {category.children.map((child) => (
+                  <li key={child.slug}>
+                    <Link href={buildHref(child.slug, category.slug)} className="hover:underline">
+                      {child.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </details>
+          )}
+        </li>
+      ))}
+    </ul>
+  </nav>
+);
+
+export default CategoryMenu;

--- a/app/components/FilterPanel.tsx
+++ b/app/components/FilterPanel.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import { useMemo, useState, useEffect } from 'react';
+import type { CategoryFilter, FilterOption } from '../types';
+
+type FilterPanelProps = {
+  title?: string;
+  filters: CategoryFilter[];
+  initialState?: FilterState;
+  onStateChange?: (state: FilterState) => void;
+};
+
+export type FilterState = Record<string, string>;
+
+const normalizeOption = (option: FilterOption) =>
+  typeof option === 'string' ? { value: option, label: option } : option;
+
+const buildDefaultState = (filters: CategoryFilter[]): FilterState => {
+  const defaults: FilterState = {};
+  filters.forEach((filter) => {
+    if (filter.default !== undefined && filter.default !== null) {
+      defaults[filter.key] = String(filter.default);
+    }
+  });
+  return defaults;
+};
+
+const areStatesEqual = (a: FilterState, b: FilterState) => {
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const key of keys) {
+    if (a[key] !== b[key]) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const FilterPanel = ({ title = 'Filters', filters, initialState, onStateChange }: FilterPanelProps) => {
+  const defaults = useMemo(() => buildDefaultState(filters), [filters]);
+  const computedInitialState = useMemo(() => ({ ...defaults, ...(initialState ?? {}) }), [defaults, initialState]);
+  const [state, setState] = useState<FilterState>(computedInitialState);
+
+  useEffect(() => {
+    setState((prev) => {
+      if (areStatesEqual(prev, computedInitialState)) {
+        return prev;
+      }
+      return computedInitialState;
+    });
+  }, [computedInitialState]);
+
+  const visibleFilters = useMemo(
+    () =>
+      filters.filter((filter) => {
+        if (!filter.visibleWhen) {
+          return true;
+        }
+        return Object.entries(filter.visibleWhen).every(([key, value]) => state[key] === String(value));
+      }),
+    [filters, state]
+  );
+
+  const handleChange = (key: string, value: string) => {
+    setState((prev) => {
+      const next = { ...prev };
+      if (value) {
+        if (prev[key] === value) {
+          return prev;
+        }
+        next[key] = value;
+      } else if (prev[key]) {
+        delete next[key];
+      } else {
+        return prev;
+      }
+      onStateChange?.(next);
+      return next;
+    });
+  };
+
+  const handleRangeChange = (key: string, part: 'min' | 'max', value: string) => {
+    const derivedKey = `${key}_${part}`;
+    setState((prev) => {
+      const next = { ...prev };
+      if (value) {
+        if (prev[derivedKey] === value) {
+          return prev;
+        }
+        next[derivedKey] = value;
+      } else if (prev[derivedKey]) {
+        delete next[derivedKey];
+      } else {
+        return prev;
+      }
+      onStateChange?.(next);
+      return next;
+    });
+  };
+
+  return (
+    <aside className="space-y-4 rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+      <header>
+        <h2 className="text-lg font-semibold text-brand-primary">{title}</h2>
+        <p className="text-xs text-slate-500">Selections update the query parameters in the live app.</p>
+      </header>
+      <dl className="space-y-4">
+        {visibleFilters.map((filter) => {
+          switch (filter.type) {
+            case 'select': {
+              const options = (filter.options ?? []).map(normalizeOption);
+              return (
+                <div key={filter.key}>
+                  <dt className="text-sm font-medium text-slate-700 capitalize">{filter.key.replace(/_/g, ' ')}</dt>
+                  <dd>
+                    <select
+                      className="mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+                      value={state[filter.key] ?? ''}
+                      onChange={(event) => handleChange(filter.key, event.target.value)}
+                    >
+                      <option value="">Any</option>
+                      {options.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </dd>
+                </div>
+              );
+            }
+            case 'segmented': {
+              const options = (filter.options ?? []).map(normalizeOption);
+              return (
+                <div key={filter.key}>
+                  <dt className="text-sm font-medium text-slate-700 capitalize">{filter.key.replace(/_/g, ' ')}</dt>
+                  <dd className="mt-2 flex flex-wrap gap-2">
+                    {options.map((option) => {
+                      const isActive = state[filter.key] === option.value;
+                      return (
+                        <button
+                          type="button"
+                          key={option.value}
+                          onClick={() => handleChange(filter.key, option.value)}
+                          className={`rounded-full border px-3 py-1 text-sm transition ${
+                            isActive
+                              ? 'border-brand-accent bg-brand-accent text-white'
+                              : 'border-slate-200 bg-slate-100 text-slate-700'
+                          }`}
+                        >
+                          {option.label}
+                        </button>
+                      );
+                    })}
+                  </dd>
+                </div>
+              );
+            }
+            case 'range': {
+              return (
+                <div key={filter.key}>
+                  <dt className="text-sm font-medium text-slate-700 capitalize">{filter.key.replace(/_/g, ' ')}</dt>
+                  <dd className="mt-2 grid grid-cols-2 gap-2 text-sm">
+                    <div>
+                      <label className="block text-xs text-slate-500" htmlFor={`${filter.key}-min`}>
+                        Min{filter.unit ? ` (${filter.unit})` : ''}
+                      </label>
+                      <input
+                        id={`${filter.key}-min`}
+                        type="number"
+                        className="mt-1 w-full rounded border border-slate-300 px-3 py-2"
+                        min={filter.min}
+                        max={filter.max}
+                        value={state[`${filter.key}_min`] ?? ''}
+                        onChange={(event) => handleRangeChange(filter.key, 'min', event.target.value)}
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs text-slate-500" htmlFor={`${filter.key}-max`}>
+                        Max{filter.unit ? ` (${filter.unit})` : ''}
+                      </label>
+                      <input
+                        id={`${filter.key}-max`}
+                        type="number"
+                        className="mt-1 w-full rounded border border-slate-300 px-3 py-2"
+                        min={filter.min}
+                        max={filter.max}
+                        value={state[`${filter.key}_max`] ?? ''}
+                        onChange={(event) => handleRangeChange(filter.key, 'max', event.target.value)}
+                      />
+                    </div>
+                  </dd>
+                </div>
+              );
+            }
+            case 'number': {
+              return (
+                <div key={filter.key}>
+                  <dt className="text-sm font-medium text-slate-700 capitalize">{filter.key.replace(/_/g, ' ')}</dt>
+                  <dd>
+                    <input
+                      type="number"
+                      className="mt-2 w-full rounded border border-slate-300 px-3 py-2"
+                      min={filter.min}
+                      max={filter.max}
+                      value={state[filter.key] ?? ''}
+                      onChange={(event) => handleChange(filter.key, event.target.value)}
+                    />
+                  </dd>
+                </div>
+              );
+            }
+            case 'date': {
+              return (
+                <div key={filter.key}>
+                  <dt className="text-sm font-medium text-slate-700 capitalize">{filter.key.replace(/_/g, ' ')}</dt>
+                  <dd>
+                    <input
+                      type="date"
+                      className="mt-2 w-full rounded border border-slate-300 px-3 py-2"
+                      value={state[filter.key] ?? ''}
+                      onChange={(event) => handleChange(filter.key, event.target.value)}
+                    />
+                  </dd>
+                </div>
+              );
+            }
+            case 'text':
+            default: {
+              return (
+                <div key={filter.key}>
+                  <dt className="text-sm font-medium text-slate-700 capitalize">{filter.key.replace(/_/g, ' ')}</dt>
+                  <dd>
+                    <input
+                      type="text"
+                      className="mt-2 w-full rounded border border-slate-300 px-3 py-2"
+                      value={state[filter.key] ?? ''}
+                      onChange={(event) => handleChange(filter.key, event.target.value)}
+                    />
+                  </dd>
+                </div>
+              );
+            }
+          }
+        })}
+      </dl>
+      <footer className="border-t border-slate-200 pt-4 text-xs text-slate-500">
+        Selected filters (mock state):
+        <pre className="mt-2 rounded bg-slate-100 p-2 text-[10px] leading-tight text-slate-700">
+          {JSON.stringify(state, null, 2)}
+        </pre>
+      </footer>
+    </aside>
+  );
+};
+
+export default FilterPanel;

--- a/app/components/ListingCard.tsx
+++ b/app/components/ListingCard.tsx
@@ -1,0 +1,65 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import type { ListingSummary } from '../types';
+
+type ListingCardProps = {
+  listing: ListingSummary;
+};
+
+const formatPrice = (value: number) => new Intl.NumberFormat('en-SA').format(value);
+
+const ListingCard = ({ listing }: ListingCardProps) => (
+  <article className="flex h-full flex-col overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
+    <div className="relative aspect-video w-full bg-slate-100">
+      {listing.imageUrl ? (
+        <Image src={listing.imageUrl} alt={listing.title} fill className="object-cover" />
+      ) : (
+        <div className="flex h-full items-center justify-center text-sm text-slate-400">Image coming soon</div>
+      )}
+    </div>
+    <div className="flex flex-1 flex-col gap-3 p-4">
+      <header className="space-y-1">
+        <h3 className="text-base font-semibold text-brand-primary">{listing.title}</h3>
+        {(listing.brandLabel || listing.modelLabel || listing.year) && (
+          <p className="text-xs uppercase tracking-wide text-slate-500">
+            {[listing.brandLabel, listing.modelLabel, listing.year].filter(Boolean).join(' · ')}
+          </p>
+        )}
+        <p className="text-sm text-slate-500">
+          SAR {formatPrice(listing.priceSar)} · {listing.city}
+        </p>
+      </header>
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        <span className="rounded bg-slate-100 px-2 py-1 font-medium uppercase text-slate-600">
+          {listing.condition}
+        </span>
+        {listing.mileageKm && (
+          <span className="rounded bg-slate-100 px-2 py-1 text-slate-600">
+            {formatPrice(listing.mileageKm)} km
+          </span>
+        )}
+        {listing.certified && (
+          <span className="rounded bg-green-100 px-2 py-1 font-semibold text-green-700">Mazad Certified</span>
+        )}
+        {listing.warrantyStatus && (
+          <span className="rounded bg-slate-100 px-2 py-1 text-slate-600">
+            Warranty: {listing.warrantyStatus}
+          </span>
+        )}
+        {typeof listing.owners === 'number' && listing.condition === 'used' && (
+          <span className="rounded bg-slate-100 px-2 py-1 text-slate-600">{listing.owners} owner(s)</span>
+        )}
+      </div>
+      <div className="mt-auto">
+        <Link
+          href={`/listings/${listing.id}`}
+          className="inline-flex w-full justify-center rounded bg-brand-accent px-3 py-2 text-sm font-semibold text-white"
+        >
+          View details
+        </Link>
+      </div>
+    </div>
+  </article>
+);
+
+export default ListingCard;

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,19 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-slate-50 text-slate-900 antialiased;
+}
+
+a {
+  @apply text-brand-accent transition-colors hover:text-orange-500;
+}
+
+.main-shell {
+  @apply mx-auto max-w-6xl px-6 py-8;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,59 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import './globals.css';
+import categoriesJson from '@/data/categories.json';
+import type { CategoriesData } from './types';
+
+const categoriesData = categoriesJson as CategoriesData;
+
+export const metadata: Metadata = {
+  title: 'Mazad.com Marketplace',
+  description: 'Saudi Arabia\'s trusted marketplace for vehicles and premium goods.'
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const primaryCategories = categoriesData.categories.slice(0, 4);
+
+  return (
+    <html lang="en">
+      <body>
+        <header className="border-b border-slate-200 bg-white">
+          <div className="main-shell flex items-center justify-between gap-6 py-4">
+            <Link href="/" className="text-xl font-bold text-brand-primary">
+              Mazad.com
+            </Link>
+            <nav aria-label="Primary navigation" className="hidden items-center gap-4 md:flex">
+              {primaryCategories.map((category) => (
+                <Link key={category.slug} href={`/categories/${category.slug}`} className="text-sm text-slate-600 hover:text-brand-primary">
+                  {category.label}
+                </Link>
+              ))}
+              <Link href="/categories" className="rounded border border-brand-accent px-3 py-1 text-sm font-medium text-brand-accent">
+                All categories
+              </Link>
+            </nav>
+            <div className="flex items-center gap-3 text-sm text-slate-600">
+              <Link href="/sellers" className="hover:text-brand-primary">
+                Sell
+              </Link>
+              <Link href="/categories/cars" className="hover:text-brand-primary">
+                Buy
+              </Link>
+            </div>
+          </div>
+        </header>
+        <main className="main-shell">{children}</main>
+        <footer className="border-t border-slate-200 bg-white">
+          <div className="main-shell flex flex-col gap-2 py-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
+            <span>© {new Date().getFullYear()} Mazad.com. All rights reserved.</span>
+            <div className="flex gap-4">
+              <Link href="#">Privacy</Link>
+              <Link href="#">Terms</Link>
+              <Link href="#">Support</Link>
+            </div>
+          </div>
+        </footer>
+      </body>
+    </html>
+  );
+}

--- a/app/lib/analytics.ts
+++ b/app/lib/analytics.ts
@@ -1,0 +1,22 @@
+'use client';
+
+export type AnalyticsPayload = Record<string, unknown>;
+
+export const trackEvent = (event: string, payload: AnalyticsPayload = {}) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const detail = {
+    event,
+    payload,
+    timestamp: new Date().toISOString()
+  };
+
+  window.dispatchEvent(new CustomEvent('mazad-analytics', { detail }));
+
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.info(`[analytics] ${event}`, payload);
+  }
+};

--- a/app/listings/ListingAnalytics.tsx
+++ b/app/listings/ListingAnalytics.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useEffect } from 'react';
+import { trackEvent } from '@/app/lib/analytics';
+
+type ListingAnalyticsProps = {
+  event: string;
+  payload: Record<string, unknown>;
+};
+
+const ListingAnalytics = ({ event, payload }: ListingAnalyticsProps) => {
+  useEffect(() => {
+    trackEvent(event, payload);
+  }, [event, payload]);
+
+  return null;
+};
+
+export default ListingAnalytics;

--- a/app/listings/[id]/page.tsx
+++ b/app/listings/[id]/page.tsx
@@ -1,0 +1,340 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import categoriesJson from '@/data/categories.json';
+import listingsJson from '@/data/listings.json';
+import type { CategoriesData, ListingsData, ListingDetail } from '@/app/types';
+import ListingCard from '@/app/components/ListingCard';
+import ListingAnalytics from '@/app/listings/ListingAnalytics';
+
+const categoriesData = categoriesJson as CategoriesData;
+const listingsData = listingsJson as ListingsData;
+
+const findListing = (id: string) => listingsData.listings.find((listing) => listing.id === id);
+
+const formatSar = (value: number) => new Intl.NumberFormat('en-SA').format(value);
+
+const formatAccidentHistory = (value?: string) => {
+  if (!value) {
+    return 'Unknown';
+  }
+  switch (value) {
+    case 'no-accidents':
+      return 'No accidents reported';
+    case 'minor':
+      return 'Minor incidents disclosed';
+    case 'major':
+      return 'Major incidents disclosed';
+    default:
+      return value.replace(/-/g, ' ');
+  }
+};
+
+const formatWarranty = (value?: string) => {
+  if (!value) {
+    return 'Not specified';
+  }
+  switch (value) {
+    case 'manufacturer':
+      return 'Manufacturer warranty';
+    case 'extended':
+      return 'Extended warranty';
+    case 'none':
+      return 'No warranty';
+    default:
+      return value.replace(/-/g, ' ');
+  }
+};
+
+const getCategoryLabel = (slug?: string) => {
+  if (!slug) {
+    return undefined;
+  }
+  return categoriesData.categories.find((category) => category.slug === slug)?.label;
+};
+
+const conditionBadgeStyles = (condition: string) =>
+  condition === 'new'
+    ? 'bg-emerald-100 text-emerald-700 border-emerald-200'
+    : 'bg-sky-100 text-sky-700 border-sky-200';
+
+const conditionIcon = (condition: string) => (condition === 'new' ? '✨' : '🛠️');
+
+const buildBreadcrumbs = (listing: ListingDetail) => {
+  const items: { label: string; href?: string }[] = [
+    { label: 'Home', href: '/' }
+  ];
+
+  const categoryLabel = getCategoryLabel(listing.categorySlug) ?? 'Marketplace';
+  if (listing.categorySlug) {
+    items.push({ label: categoryLabel, href: `/categories/${listing.categorySlug}` });
+  }
+
+  if (listing.brandSlug && listing.brandLabel) {
+    items.push({ label: listing.brandLabel, href: `/categories/cars/${listing.brandSlug}` });
+  }
+
+  if (listing.brandSlug && listing.modelSlug && listing.modelLabel) {
+    items.push({ label: listing.modelLabel, href: `/categories/cars/${listing.brandSlug}/${listing.modelSlug}` });
+  }
+
+  items.push({ label: listing.title });
+
+  return items;
+};
+
+export default function ListingDetailPage({ params }: { params: { id: string } }) {
+  const listing = findListing(params.id);
+
+  if (!listing) {
+    notFound();
+  }
+
+  const relatedListings = listing.relatedListingIds
+    .map((relatedId) => listingsData.listings.find((candidate) => candidate.id === relatedId))
+    .filter((candidate): candidate is ListingDetail => Boolean(candidate) && candidate.id !== listing.id)
+    .slice(0, 4);
+
+  const inspection = listing.inspection;
+  const isCertified = Boolean(listing.certified || inspection?.certified);
+
+  const breadcrumbs = buildBreadcrumbs(listing);
+
+  const specs = [
+    { label: 'Body type', value: listing.bodyType },
+    { label: 'Transmission', value: listing.transmission },
+    { label: 'Drivetrain', value: listing.drivetrain },
+    { label: 'Fuel type', value: listing.fuelType },
+    { label: 'Exterior color', value: listing.exteriorColor },
+    { label: 'Interior color', value: listing.interiorColor }
+  ].filter((entry) => Boolean(entry.value));
+
+  const conditionDetails = [
+    { label: 'Mileage', value: listing.mileageKm ? `${formatSar(listing.mileageKm)} km` : undefined },
+    { label: 'Previous owners', value: typeof listing.owners === 'number' ? `${listing.owners}` : undefined },
+    { label: 'Accident history', value: formatAccidentHistory(listing.accidentHistory) },
+    { label: 'Warranty', value: formatWarranty(listing.warrantyStatus) }
+  ].filter((entry) => Boolean(entry.value));
+
+  return (
+    <div className="space-y-8">
+      <ListingAnalytics
+        event="listing_view"
+        payload={{
+          listingId: listing.id,
+          certified: isCertified,
+          brand: listing.brandSlug,
+          model: listing.modelSlug
+        }}
+      />
+      <nav aria-label="Breadcrumb" className="text-sm text-slate-500">
+        <ol className="flex flex-wrap items-center gap-2">
+          {breadcrumbs.map((item, index) => (
+            <li key={`${item.label}-${index}`} className="flex items-center gap-2">
+              {index > 0 && <span className="text-slate-400">/</span>}
+              {item.href ? (
+                <Link href={item.href} className="hover:text-brand-primary">
+                  {item.label}
+                </Link>
+              ) : (
+                <span className="text-slate-600">{item.label}</span>
+              )}
+            </li>
+          ))}
+        </ol>
+      </nav>
+      <div className="grid gap-8 lg:grid-cols-[2fr,1fr]">
+        <section className="space-y-6">
+          <header className="space-y-4 rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div>
+                <p className="text-sm uppercase tracking-wide text-slate-500">
+                  {listing.brandLabel} · {listing.modelLabel} · {listing.year}
+                </p>
+                <h1 className="text-3xl font-bold text-brand-primary">{listing.title}</h1>
+              </div>
+              <div className="text-right">
+                <div className="text-sm text-slate-500">Starting bid</div>
+                <div className="text-2xl font-semibold text-brand-primary">SAR {formatSar(listing.priceSar)}</div>
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center gap-3 text-xs">
+              <span className={`inline-flex items-center gap-1 rounded-full border px-3 py-1 font-semibold ${conditionBadgeStyles(listing.condition)}`}>
+                <span aria-hidden>{conditionIcon(listing.condition)}</span>
+                <span className="uppercase">{listing.condition}</span>
+              </span>
+              <span className="rounded-full bg-slate-100 px-3 py-1 text-slate-600">{listing.city}</span>
+              {listing.trimLabel && (
+                <span className="rounded-full bg-slate-100 px-3 py-1 text-slate-600">Trim: {listing.trimLabel}</span>
+              )}
+              {isCertified && (
+                <span className="rounded-full bg-green-100 px-3 py-1 text-green-700">Mazad Certified</span>
+              )}
+            </div>
+          </header>
+          <section className="space-y-4">
+            <h2 className="text-xl font-semibold text-brand-primary">Photo gallery</h2>
+            <div className="grid gap-4 md:grid-cols-2">
+              {listing.photos.map((photo) => (
+                <div
+                  key={photo.id}
+                  className="flex h-48 flex-col justify-between rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600"
+                >
+                  <span className="font-medium text-slate-700">{photo.caption}</span>
+                  <span className="text-xs uppercase tracking-wide text-slate-400">Image placeholder</span>
+                </div>
+              ))}
+            </div>
+          </section>
+          <section className="space-y-4">
+            <h2 className="text-xl font-semibold text-brand-primary">Vehicle overview</h2>
+            <p className="text-sm text-slate-600">{listing.description}</p>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Key specifications</h3>
+                <dl className="space-y-2 text-sm text-slate-600">
+                  {specs.map((spec) => (
+                    <div key={spec.label} className="flex justify-between gap-4">
+                      <dt className="font-medium">{spec.label}</dt>
+                      <dd>{spec.value}</dd>
+                    </div>
+                  ))}
+                </dl>
+              </div>
+              <div className="space-y-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Condition & history</h3>
+                <dl className="space-y-2 text-sm text-slate-600">
+                  {conditionDetails.map((detail) => (
+                    <div key={detail.label} className="flex justify-between gap-4">
+                      <dt className="font-medium">{detail.label}</dt>
+                      <dd className="text-right">{detail.value}</dd>
+                    </div>
+                  ))}
+                </dl>
+              </div>
+            </div>
+            {listing.features.length > 0 && (
+              <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Highlights</h3>
+                <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-slate-600">
+                  {listing.features.map((feature) => (
+                    <li key={feature}>{feature}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </section>
+          {inspection && (
+            <section className="space-y-4 rounded-lg border border-brand-accent bg-orange-50 p-6 text-sm text-brand-primary">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <h2 className="text-lg font-semibold">Inspection & certification</h2>
+                {inspection.certified ? (
+                  <span className="rounded-full bg-white px-3 py-1 text-sm font-semibold text-brand-primary">
+                    Certified on {inspection.inspectionDate}
+                  </span>
+                ) : (
+                  <span className="rounded-full bg-white px-3 py-1 text-sm text-brand-primary">
+                    Eligible for Mazad Certified program
+                  </span>
+                )}
+              </div>
+              <p className="text-brand-primary/80">{inspection.summary}</p>
+              {inspection.inspector && (
+                <div className="text-xs uppercase tracking-wide text-brand-primary/70">
+                  Inspector: {inspection.inspector}
+                </div>
+              )}
+              {inspection.checklist.length > 0 && (
+                <ul className="mt-3 grid gap-2 md:grid-cols-2">
+                  {inspection.checklist.map((item) => (
+                    <li key={item.item} className="rounded bg-white px-3 py-2 text-brand-primary">
+                      <span className="font-semibold">{item.item}</span>
+                      <span className="ml-2 text-xs uppercase">{item.status}</span>
+                      {item.notes && <span className="block text-xs text-brand-primary/70">{item.notes}</span>}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          )}
+          {relatedListings.length > 0 && (
+            <section className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h2 className="text-xl font-semibold text-brand-primary">Related listings</h2>
+                <Link href={`/categories/cars/${listing.brandSlug ?? 'cars'}`} className="text-sm text-brand-accent">
+                  View more {listing.brandLabel} vehicles
+                </Link>
+              </div>
+              <div className="grid gap-6 md:grid-cols-2">
+                {relatedListings.map((related) => (
+                  <ListingCard key={related.id} listing={related} />
+                ))}
+              </div>
+            </section>
+          )}
+        </section>
+        <aside className="space-y-6">
+          <div className="space-y-4 rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+            <div>
+              <h2 className="text-lg font-semibold text-brand-primary">Bid summary</h2>
+              <p className="text-sm text-slate-500">Transparent pricing powered by Mazad.com auction rules.</p>
+            </div>
+            <dl className="space-y-2 text-sm text-slate-600">
+              <div className="flex justify-between">
+                <dt>Current ask</dt>
+                <dd className="font-semibold text-brand-primary">SAR {formatSar(listing.priceSar)}</dd>
+              </div>
+              {listing.mileageKm && (
+                <div className="flex justify-between">
+                  <dt>Mileage</dt>
+                  <dd>{formatSar(listing.mileageKm)} km</dd>
+                </div>
+              )}
+              <div className="flex justify-between">
+                <dt>Location</dt>
+                <dd>{listing.city}</dd>
+              </div>
+            </dl>
+            <div className="space-y-2 text-sm">
+              <button
+                type="button"
+                className="w-full rounded bg-brand-accent px-4 py-2 font-semibold text-white shadow-sm"
+              >
+                Place a bid (prototype)
+              </button>
+              <button
+                type="button"
+                className="w-full rounded border border-brand-accent px-4 py-2 font-semibold text-brand-accent"
+              >
+                Follow listing
+              </button>
+            </div>
+          </div>
+          <div className="space-y-3 rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="text-lg font-semibold text-brand-primary">Seller information</h2>
+            <div className="rounded border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
+              <div className="flex items-center justify-between">
+                <span className="font-semibold text-brand-primary">{listing.seller.name}</span>
+                {listing.seller.verified && (
+                  <span className="rounded-full bg-green-100 px-3 py-1 text-xs font-semibold text-green-700">Verified</span>
+                )}
+              </div>
+              <ul className="mt-3 space-y-2">
+                <li>Rating: {listing.seller.rating.toFixed(1)} / 5</li>
+                <li>Total sales: {listing.seller.totalSales}</li>
+                <li>Response time: {listing.seller.responseTime}</li>
+              </ul>
+            </div>
+          </div>
+          <div className="space-y-3 rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="text-lg font-semibold text-brand-primary">Next steps</h2>
+            <ul className="space-y-2 text-sm text-slate-600">
+              <li>• Schedule a viewing or remote video inspection.</li>
+              <li>• Request detailed inspection PDF from seller.</li>
+              <li>• Explore financing & insurance options (coming soon).</li>
+            </ul>
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="space-y-4 text-center">
+      <h1 className="text-3xl font-bold text-brand-primary">Page not found</h1>
+      <p className="text-slate-600">
+        We couldn\'t find the taxonomy node you were looking for. Review the category tree or return home to continue browsing.
+      </p>
+      <div className="flex justify-center gap-3">
+        <Link href="/" className="rounded bg-brand-accent px-4 py-2 text-sm font-semibold text-white">
+          Back to home
+        </Link>
+        <Link href="/categories" className="rounded border border-brand-accent px-4 py-2 text-sm font-semibold text-brand-accent">
+          View categories
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,73 @@
+import CategoryMenu from './components/CategoryMenu';
+import ListingCard from './components/ListingCard';
+import categoriesJson from '@/data/categories.json';
+import listingsJson from '@/data/listings.json';
+import type { CategoriesData, ListingsData } from './types';
+
+const categoriesData = categoriesJson as CategoriesData;
+const listingsData = listingsJson as ListingsData;
+const featuredListings = listingsData.listings.filter((listing) => listing.categorySlug === 'vehicles').slice(0, 3);
+
+export default function HomePage() {
+  return (
+    <div className="space-y-12">
+      <section className="grid gap-6 rounded-xl bg-white p-8 shadow-sm md:grid-cols-[3fr,2fr]">
+        <div className="space-y-4">
+          <span className="rounded-full bg-slate-100 px-3 py-1 text-xs uppercase tracking-wide text-slate-600">
+            Marketplace MVP
+          </span>
+          <h1 className="text-3xl font-bold text-brand-primary">
+            Trusted auctions for vehicles and premium assets in Saudi Arabia
+          </h1>
+          <p className="text-base text-slate-600">
+            Explore curated listings backed by inspection-ready data and localized taxonomies. Buyers and sellers gain confidence
+            with Mazad Certified workflows and transparent filters.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <a
+              href="/categories/cars"
+              className="rounded bg-brand-accent px-4 py-2 text-sm font-semibold text-white shadow"
+            >
+              Browse vehicles
+            </a>
+            <a href="/sellers" className="rounded border border-brand-accent px-4 py-2 text-sm font-semibold text-brand-accent">
+              Become a seller
+            </a>
+          </div>
+        </div>
+        <div className="rounded-lg border border-dashed border-brand-accent bg-orange-50 p-6 text-sm text-brand-primary">
+          <h2 className="text-lg font-semibold">Phase 1 Highlights</h2>
+          <ul className="mt-4 space-y-2 list-disc pl-4">
+            <li>Vehicles taxonomy with brand → model → trim flows.</li>
+            <li>Buyer & seller journeys documented with clear acceptance criteria.</li>
+            <li>Reusable filters schema powering conditional logic for used vehicles.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-semibold text-brand-primary">Browse by category</h2>
+          <a href="/docs/10-category-tree.md" className="text-sm text-slate-600 hover:text-brand-primary">
+            View taxonomy doc
+          </a>
+        </div>
+        <CategoryMenu categories={categoriesData.categories} />
+      </section>
+
+      <section className="space-y-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-semibold text-brand-primary">Featured vehicle listings</h2>
+          <a href="/categories/cars" className="text-sm text-slate-600 hover:text-brand-primary">
+            View all cars
+          </a>
+        </div>
+        <div className="grid gap-6 md:grid-cols-3">
+          {featuredListings.map((listing) => (
+            <ListingCard key={listing.id} listing={listing} />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/sellers/page.tsx
+++ b/app/sellers/page.tsx
@@ -1,0 +1,640 @@
+'use client';
+
+import { FormEvent, useMemo, useState } from 'react';
+import Link from 'next/link';
+import vehiclesJson from '@/data/vehicles/vehicles.json';
+import listingsJson from '@/data/listings.json';
+import type { VehiclesData, ListingsData, VehicleBrand, VehicleModel } from '@/app/types';
+
+const vehiclesData = vehiclesJson as VehiclesData;
+const listingsData = listingsJson as ListingsData;
+
+const registrationDefaults = {
+  businessName: '',
+  crNumber: '',
+  city: '',
+  email: '',
+  phone: '',
+  verificationMethod: 'upload' as 'upload' | 'code',
+  verificationCode: '',
+  licenseFileName: ''
+};
+
+type RegistrationState = typeof registrationDefaults;
+
+type ListingFormState = {
+  brandSlug: string;
+  modelSlug: string;
+  year: string;
+  trim: string;
+  condition: 'new' | 'used';
+  mileage: string;
+  priceSar: string;
+  inspectionReady: boolean;
+  photoCount: number;
+  inspectionDocument: boolean;
+};
+
+type ListingStatus = 'Active' | 'Paused' | 'Sold' | 'Pending Review';
+
+type ManagedListing = {
+  id: string;
+  title: string;
+  status: ListingStatus;
+  watchers: number;
+  lastUpdated: string;
+};
+
+type AuditEntry = {
+  id: string;
+  title: string;
+  status: ListingStatus;
+  note: string;
+  timestamp: string;
+};
+
+const formatDateTime = (iso: string) => new Date(iso).toLocaleString('en-SA');
+
+const SellerPage = () => {
+  const [registration, setRegistration] = useState<RegistrationState>(registrationDefaults);
+  const [registrationStatus, setRegistrationStatus] = useState<'draft' | 'submitted'>('draft');
+  const [registrationMessage, setRegistrationMessage] = useState<string | null>(null);
+
+  const [listingForm, setListingForm] = useState<ListingFormState>({
+    brandSlug: '',
+    modelSlug: '',
+    year: '',
+    trim: '',
+    condition: 'used',
+    mileage: '',
+    priceSar: '',
+    inspectionReady: true,
+    photoCount: 6,
+    inspectionDocument: true
+  });
+  const [listingSubmissionSummary, setListingSubmissionSummary] = useState<ListingFormState | null>(null);
+
+  const eliteListings = useMemo(
+    () =>
+      listingsData.listings
+        .filter((listing) => listing.seller.name === 'Elite Motors KSA')
+        .slice(0, 3)
+        .map<ManagedListing>((listing, index) => ({
+          id: listing.id,
+          title: listing.title,
+          status: 'Active',
+          watchers: 42 - index * 7,
+          lastUpdated: new Date().toISOString()
+        })),
+    []
+  );
+
+  const [managedListings, setManagedListings] = useState<ManagedListing[]>(eliteListings);
+  const [auditTrail, setAuditTrail] = useState<AuditEntry[]>([]);
+
+  const handleRegistrationChange = (field: keyof RegistrationState, value: string) => {
+    setRegistration((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleRegistrationSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setRegistrationStatus('submitted');
+    setRegistrationMessage(
+      'Verification workflow triggered. Expect email confirmation within 1 business day while dashboard shows Pending Verification.'
+    );
+  };
+
+  const selectedBrand: VehicleBrand | undefined = useMemo(
+    () => vehiclesData.brands.find((brand) => brand.brand === listingForm.brandSlug),
+    [listingForm.brandSlug]
+  );
+
+  const modelsForBrand: VehicleModel[] = useMemo(
+    () => selectedBrand?.models ?? [],
+    [selectedBrand]
+  );
+
+  const selectedModel: VehicleModel | undefined = useMemo(
+    () => modelsForBrand.find((model) => model.model === listingForm.modelSlug),
+    [listingForm.modelSlug, modelsForBrand]
+  );
+
+  const trimsForModel = selectedModel?.trims ?? [];
+  const yearsForModel = selectedModel
+    ? Array.from({ length: selectedModel.year_max - selectedModel.year_min + 1 }, (_, index) => (
+        selectedModel.year_min + index
+      )).reverse()
+    : [];
+
+  const handleListingChange = (field: keyof ListingFormState, value: string | number | boolean) => {
+    setListingForm((prev) => {
+      const next = { ...prev };
+      if (field === 'brandSlug') {
+        next.brandSlug = value as string;
+        next.modelSlug = '';
+        next.trim = '';
+        next.year = '';
+      } else if (field === 'modelSlug') {
+        next.modelSlug = value as string;
+        next.trim = '';
+        next.year = '';
+      } else if (field === 'trim') {
+        next.trim = value as string;
+      } else if (field === 'condition') {
+        next.condition = value as 'new' | 'used';
+        if (next.condition === 'new') {
+          next.mileage = '0';
+        }
+      } else if (field === 'inspectionReady') {
+        next.inspectionReady = value as boolean;
+      } else if (field === 'inspectionDocument') {
+        next.inspectionDocument = value as boolean;
+      } else if (field === 'photoCount') {
+        next.photoCount = Number(value);
+      } else if (field === 'mileage') {
+        next.mileage = value as string;
+      } else if (field === 'priceSar') {
+        next.priceSar = value as string;
+      } else if (field === 'year') {
+        next.year = value as string;
+      }
+      return next;
+    });
+  };
+
+  const handleListingSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setListingSubmissionSummary(listingForm);
+    const listingTitle = `${selectedBrand?.label ?? 'Vehicle'} ${selectedModel?.label ?? ''} ${listingForm.year}`.trim();
+    const draftId = `draft-${Date.now()}`;
+    setManagedListings((prev) => [
+      {
+        id: draftId,
+        title: listingTitle,
+        status: 'Pending Review',
+        watchers: 0,
+        lastUpdated: new Date().toISOString()
+      },
+      ...prev
+    ]);
+    setAuditTrail((prev) => [
+      {
+        id: draftId,
+        title: listingTitle,
+        status: 'Pending Review',
+        note: 'Listing entered moderation queue with 24h SLA.',
+        timestamp: new Date().toISOString()
+      },
+      ...prev
+    ]);
+  };
+
+  const handleStatusChange = (id: string, status: ListingStatus) => {
+    const note =
+      status === 'Paused'
+        ? 'Followers will be notified that the listing is paused.'
+        : status === 'Sold'
+        ? 'Followers notified of sale and listing archived.'
+        : status === 'Active'
+        ? 'Listing reactivated and sent for moderation review.'
+        : 'Listing awaiting moderation.';
+
+    let listingTitle = 'Listing';
+    setManagedListings((prev) =>
+      prev.map((entry) => {
+        if (entry.id === id) {
+          listingTitle = entry.title;
+          return {
+            ...entry,
+            status,
+            lastUpdated: new Date().toISOString()
+          };
+        }
+        return entry;
+      })
+    );
+    setAuditTrail((prev) => [
+      {
+        id,
+        title: listingTitle,
+        status,
+        note,
+        timestamp: new Date().toISOString()
+      },
+      ...prev
+    ]);
+  };
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-4 rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-slate-500">Seller workspace</p>
+            <h1 className="text-3xl font-bold text-brand-primary">Mazad.com seller onboarding</h1>
+          </div>
+          <span
+            className={`rounded-full px-3 py-1 text-xs font-semibold ${
+              registrationStatus === 'submitted'
+                ? 'bg-yellow-100 text-yellow-700'
+                : 'bg-slate-100 text-slate-600'
+            }`}
+          >
+            {registrationStatus === 'submitted' ? 'Pending Verification' : 'Complete your profile'}
+          </span>
+        </div>
+        <p className="text-sm text-slate-600">
+          Register your business, publish high-quality vehicle listings, and manage inventory updates with moderation-friendly workflows.
+        </p>
+        <div className="flex flex-wrap gap-3 text-xs text-slate-500">
+          <span>• Business verification within 1 business day</span>
+          <span>• Vehicles taxonomy integrated into listing flow</span>
+          <span>• Status changes notify followers automatically</span>
+        </div>
+      </header>
+
+      <section className="grid gap-6 lg:grid-cols-[3fr,2fr]">
+        <form onSubmit={handleRegistrationSubmit} className="space-y-5 rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-brand-primary">1. Register as a seller</h2>
+              <p className="text-sm text-slate-600">Capture business credentials to activate your seller dashboard.</p>
+            </div>
+            <span className="rounded-full bg-slate-100 px-3 py-1 text-xs text-slate-600">Phase: MVP1</span>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="text-sm">
+              <span className="block text-xs font-semibold uppercase tracking-wide text-slate-500">Business name</span>
+              <input
+                required
+                value={registration.businessName}
+                onChange={(event) => handleRegistrationChange('businessName', event.target.value)}
+                className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+                placeholder="Elite Motors KSA"
+              />
+            </label>
+            <label className="text-sm">
+              <span className="block text-xs font-semibold uppercase tracking-wide text-slate-500">Commercial registration #</span>
+              <input
+                required
+                value={registration.crNumber}
+                onChange={(event) => handleRegistrationChange('crNumber', event.target.value)}
+                className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+                placeholder="1010XXXXXX"
+              />
+            </label>
+            <label className="text-sm">
+              <span className="block text-xs font-semibold uppercase tracking-wide text-slate-500">City</span>
+              <input
+                required
+                value={registration.city}
+                onChange={(event) => handleRegistrationChange('city', event.target.value)}
+                className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+                placeholder="Riyadh"
+              />
+            </label>
+            <label className="text-sm">
+              <span className="block text-xs font-semibold uppercase tracking-wide text-slate-500">Primary contact email</span>
+              <input
+                required
+                type="email"
+                value={registration.email}
+                onChange={(event) => handleRegistrationChange('email', event.target.value)}
+                className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+                placeholder="sales@elitemotors.sa"
+              />
+            </label>
+            <label className="text-sm">
+              <span className="block text-xs font-semibold uppercase tracking-wide text-slate-500">Phone</span>
+              <input
+                required
+                value={registration.phone}
+                onChange={(event) => handleRegistrationChange('phone', event.target.value)}
+                className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+                placeholder="+9665XXXXXXX"
+              />
+            </label>
+            <label className="text-sm">
+              <span className="block text-xs font-semibold uppercase tracking-wide text-slate-500">Verification method</span>
+              <select
+                value={registration.verificationMethod}
+                onChange={(event) => handleRegistrationChange('verificationMethod', event.target.value)}
+                className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+              >
+                <option value="upload">Upload trade license</option>
+                <option value="code">Enter verification code</option>
+              </select>
+            </label>
+          </div>
+          {registration.verificationMethod === 'upload' ? (
+            <label className="text-sm">
+              <span className="block text-xs font-semibold uppercase tracking-wide text-slate-500">Trade license</span>
+              <input
+                type="file"
+                onChange={(event) =>
+                  handleRegistrationChange('licenseFileName', event.target.files?.[0]?.name ?? '')
+                }
+                className="mt-1 w-full text-sm"
+              />
+              {registration.licenseFileName && (
+                <span className="mt-1 block text-xs text-slate-500">Uploaded: {registration.licenseFileName}</span>
+              )}
+            </label>
+          ) : (
+            <label className="text-sm">
+              <span className="block text-xs font-semibold uppercase tracking-wide text-slate-500">Verification code</span>
+              <input
+                required
+                value={registration.verificationCode}
+                onChange={(event) => handleRegistrationChange('verificationCode', event.target.value)}
+                className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+                placeholder="Enter code"
+              />
+            </label>
+          )}
+          <button type="submit" className="w-full rounded bg-brand-accent px-4 py-2 text-sm font-semibold text-white">
+            Submit registration
+          </button>
+          {registrationMessage && (
+            <p className="rounded border border-dashed border-brand-accent bg-orange-50 p-3 text-xs text-brand-primary">
+              {registrationMessage}
+            </p>
+          )}
+        </form>
+        <div className="space-y-4 rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 className="text-lg font-semibold text-brand-primary">Verification checklist</h3>
+          <ul className="list-disc space-y-2 pl-5 text-sm text-slate-600">
+            <li>Upload trade license or enter Mazad verification code.</li>
+            <li>Confirm business contact information for compliance outreach.</li>
+            <li>Approval emails sent within 24 hours – dashboard reflects Pending Verification until completed.</li>
+          </ul>
+          <div className="rounded border border-slate-200 bg-slate-50 p-4 text-xs text-slate-500">
+            Once approved, your seller dashboard unlocks listing analytics, certification requests, and payout settings.
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-6 rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-brand-primary">2. Create a vehicle listing</h2>
+            <p className="text-sm text-slate-600">Use Mazad.com taxonomy to ensure consistent brand → model → trim flows.</p>
+          </div>
+          <span className="rounded-full bg-slate-100 px-3 py-1 text-xs text-slate-600">Phase: MVP1</span>
+        </div>
+        <form onSubmit={handleListingSubmit} className="grid gap-4 md:grid-cols-2">
+          <label className="text-sm">
+            <span className="block text-xs font-semibold uppercase tracking-wide text-slate-500">Brand</span>
+            <select
+              required
+              value={listingForm.brandSlug}
+              onChange={(event) => handleListingChange('brandSlug', event.target.value)}
+              className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+            >
+              <option value="">Select brand</option>
+              {vehiclesData.brands.map((brand) => (
+                <option key={brand.brand} value={brand.brand}>
+                  {brand.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm">
+            <span className="block text-xs font-semibold uppercase tracking-wide text-slate-500">Model</span>
+            <select
+              required
+              value={listingForm.modelSlug}
+              onChange={(event) => handleListingChange('modelSlug', event.target.value)}
+              className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+              disabled={!listingForm.brandSlug}
+            >
+              <option value="">Select model</option>
+              {modelsForBrand.map((model) => (
+                <option key={model.model} value={model.model}>
+                  {model.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm">
+            <span className="block text-xs font-semibold uppercase tracking-wide text-slate-500">Model year</span>
+            <select
+              required
+              value={listingForm.year}
+              onChange={(event) => handleListingChange('year', event.target.value)}
+              className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+              disabled={!listingForm.modelSlug}
+            >
+              <option value="">Select year</option>
+              {yearsForModel.map((year) => (
+                <option key={year} value={year}>
+                  {year}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm">
+            <span className="block text-xs font-semibold uppercase tracking-wide text-slate-500">Trim</span>
+            <select
+              required
+              value={listingForm.trim}
+              onChange={(event) => handleListingChange('trim', event.target.value)}
+              className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+              disabled={!listingForm.modelSlug}
+            >
+              <option value="">Select trim</option>
+              {trimsForModel.map((trim) => (
+                <option key={trim.trim} value={trim.trim}>
+                  {trim.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm">
+            <span className="block text-xs font-semibold uppercase tracking-wide text-slate-500">Condition</span>
+            <div className="mt-2 flex gap-3">
+              <label className="inline-flex items-center gap-2 text-xs">
+                <input
+                  type="radio"
+                  name="condition"
+                  value="new"
+                  checked={listingForm.condition === 'new'}
+                  onChange={(event) => handleListingChange('condition', event.target.value)}
+                />
+                New
+              </label>
+              <label className="inline-flex items-center gap-2 text-xs">
+                <input
+                  type="radio"
+                  name="condition"
+                  value="used"
+                  checked={listingForm.condition === 'used'}
+                  onChange={(event) => handleListingChange('condition', event.target.value)}
+                />
+                Used
+              </label>
+            </div>
+          </label>
+          {listingForm.condition === 'used' && (
+            <label className="text-sm">
+              <span className="block text-xs font-semibold uppercase tracking-wide text-slate-500">Mileage (km)</span>
+              <input
+                required
+                value={listingForm.mileage}
+                onChange={(event) => handleListingChange('mileage', event.target.value)}
+                className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+                placeholder="25000"
+              />
+            </label>
+          )}
+          <label className="text-sm">
+            <span className="block text-xs font-semibold uppercase tracking-wide text-slate-500">Price expectation (SAR)</span>
+            <input
+              required
+              value={listingForm.priceSar}
+              onChange={(event) => handleListingChange('priceSar', event.target.value)}
+              className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+              placeholder="250000"
+            />
+          </label>
+          <label className="text-sm">
+            <span className="block text-xs font-semibold uppercase tracking-wide text-slate-500">Photos ready</span>
+            <input
+              type="number"
+              min={6}
+              value={listingForm.photoCount}
+              onChange={(event) => handleListingChange('photoCount', event.target.value)}
+              className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm"
+            />
+            <span className="mt-1 block text-xs text-slate-500">Upload at least 6 high-resolution photos.</span>
+          </label>
+          <label className="text-sm">
+            <span className="block text-xs font-semibold uppercase tracking-wide text-slate-500">Inspection ready?</span>
+            <div className="mt-1 flex gap-3 text-xs">
+              <label className="inline-flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={listingForm.inspectionReady}
+                  onChange={(event) => handleListingChange('inspectionReady', event.target.checked)}
+                />
+                Inspection slot confirmed
+              </label>
+              <label className="inline-flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={listingForm.inspectionDocument}
+                  onChange={(event) => handleListingChange('inspectionDocument', event.target.checked)}
+                />
+                Inspection PDF ready
+              </label>
+            </div>
+          </label>
+          <div className="md:col-span-2">
+            <button type="submit" className="rounded bg-brand-accent px-4 py-2 text-sm font-semibold text-white">
+              Submit listing for moderation
+            </button>
+          </div>
+        </form>
+        {listingSubmissionSummary && (
+          <div className="rounded border border-dashed border-brand-accent bg-orange-50 p-4 text-sm text-brand-primary">
+            <h3 className="text-base font-semibold">Submission queued</h3>
+            <p className="mt-1 text-brand-primary/80">
+              Brand: {selectedBrand?.label ?? listingSubmissionSummary.brandSlug} · Model: {selectedModel?.label ?? listingSubmissionSummary.modelSlug} · Year: {listingSubmissionSummary.year}
+            </p>
+            <p className="text-xs">
+              Moderation SLA: 24 hours. Critical edits will re-open the review workflow automatically.
+            </p>
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-6 rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-brand-primary">3. Manage listings</h2>
+            <p className="text-sm text-slate-600">Update availability, pause sold inventory, and keep buyers informed.</p>
+          </div>
+          <span className="rounded-full bg-slate-100 px-3 py-1 text-xs text-slate-600">Phase: MVP1</span>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200 text-sm">
+            <thead className="bg-slate-50">
+              <tr className="text-left text-xs uppercase tracking-wide text-slate-500">
+                <th className="px-3 py-2">Listing</th>
+                <th className="px-3 py-2">Status</th>
+                <th className="px-3 py-2">Watchers</th>
+                <th className="px-3 py-2">Last updated</th>
+                <th className="px-3 py-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 text-slate-600">
+              {managedListings.map((listing) => (
+                <tr key={listing.id}>
+                  <td className="px-3 py-2 font-medium text-brand-primary">{listing.title}</td>
+                  <td className="px-3 py-2">
+                    <span
+                      className={`rounded-full px-3 py-1 text-xs font-semibold ${
+                        listing.status === 'Active'
+                          ? 'bg-green-100 text-green-700'
+                          : listing.status === 'Sold'
+                          ? 'bg-slate-900 text-white'
+                          : listing.status === 'Paused'
+                          ? 'bg-yellow-100 text-yellow-700'
+                          : 'bg-slate-200 text-slate-700'
+                      }`}
+                    >
+                      {listing.status}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2">{listing.watchers}</td>
+                  <td className="px-3 py-2 text-xs">{formatDateTime(listing.lastUpdated)}</td>
+                  <td className="px-3 py-2">
+                    <select
+                      value={listing.status}
+                      onChange={(event) => handleStatusChange(listing.id, event.target.value as ListingStatus)}
+                      className="rounded border border-slate-300 px-2 py-1 text-xs"
+                    >
+                      <option value="Active">Active</option>
+                      <option value="Paused">Paused</option>
+                      <option value="Sold">Sold</option>
+                    </select>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <div className="grid gap-4 lg:grid-cols-[2fr,1fr]">
+          <div className="space-y-3 rounded border border-slate-200 bg-slate-50 p-4 text-xs text-slate-600">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Audit trail</h3>
+            {auditTrail.length === 0 ? (
+              <p>No activity logged yet.</p>
+            ) : (
+              <ul className="space-y-2">
+                {auditTrail.slice(0, 6).map((entry) => (
+                  <li key={`${entry.id}-${entry.timestamp}`}>
+                    <span className="font-semibold text-brand-primary">{entry.title}</span> → {entry.status}{' '}
+                    <span className="text-slate-500">({formatDateTime(entry.timestamp)})</span>
+                    <div>{entry.note}</div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+          <div className="space-y-3 rounded border border-slate-200 bg-slate-50 p-4 text-xs text-slate-600">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Operational notes</h3>
+            <ul className="space-y-2">
+              <li>• Pausing or selling a listing automatically notifies followers via email/SMS.</li>
+              <li>• Critical detail edits (price, mileage) re-queue the listing for moderation review.</li>
+              <li>
+                • Access <Link href="/docs/31-user-stories-seller.md" className="text-brand-accent underline">seller stories</Link> for acceptance criteria references.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default SellerPage;

--- a/app/types.ts
+++ b/app/types.ts
@@ -1,0 +1,144 @@
+export type CategoryNode = {
+  slug: string;
+  label: string;
+  description?: string;
+  icon?: string;
+  featuredFilters?: string[];
+  children?: CategoryNode[];
+};
+
+export type CategoriesData = {
+  version: string;
+  categories: CategoryNode[];
+};
+
+export type FilterOption = string | { value: string; label: string };
+
+export type CategoryFilter = {
+  key: string;
+  type: 'select' | 'range' | 'segmented' | 'number' | 'date' | 'text';
+  options?: FilterOption[];
+  source?: string;
+  dependsOn?: string;
+  min?: number;
+  max?: number;
+  unit?: string;
+  default?: string | number;
+  visibleWhen?: Record<string, string | number | boolean>;
+};
+
+export type FiltersData = {
+  version: string;
+  filters: Record<string, CategoryFilter[]>;
+};
+
+export type VehicleTrim = {
+  trim: string;
+  label: string;
+  engine?: string;
+  drivetrain?: string;
+  transmission?: string;
+  fuel?: string;
+  years: number[];
+};
+
+export type VehicleCondition = {
+  options: string[];
+  usedOnlyAttributes: { key: string; label: string }[];
+};
+
+export type VehicleModel = {
+  model: string;
+  label: string;
+  bodyType: string;
+  year_min: number;
+  year_max: number;
+  trims: VehicleTrim[];
+  condition: VehicleCondition;
+};
+
+export type VehicleBrand = {
+  brand: string;
+  label: string;
+  origin: string;
+  popularInKsa: boolean;
+  models: VehicleModel[];
+};
+
+export type VehiclesData = {
+  version: string;
+  generatedAt: string;
+  brands: VehicleBrand[];
+};
+
+export type ListingSummary = {
+  id: string;
+  title: string;
+  priceSar: number;
+  city: string;
+  citySlug?: string;
+  condition: 'new' | 'used';
+  mileageKm?: number;
+  certified?: boolean;
+  imageUrl?: string;
+  categorySlug?: string;
+  subcategorySlug?: string;
+  brandSlug?: string;
+  brandLabel?: string;
+  modelSlug?: string;
+  modelLabel?: string;
+  year?: number;
+  trim?: string;
+  trimLabel?: string;
+  owners?: number;
+  accidentHistory?: string;
+  warrantyStatus?: string;
+};
+
+export type ListingMedia = {
+  id: string;
+  caption: string;
+  url?: string;
+};
+
+export type ListingInspectionChecklistItem = {
+  item: string;
+  status: 'pass' | 'attention' | 'fail';
+  notes?: string;
+};
+
+export type ListingInspection = {
+  certified: boolean;
+  inspectionDate?: string;
+  inspector?: string;
+  summary: string;
+  checklist: ListingInspectionChecklistItem[];
+};
+
+export type ListingSeller = {
+  name: string;
+  rating: number;
+  totalSales: number;
+  responseTime: string;
+  verified: boolean;
+};
+
+export type ListingDetail = ListingSummary & {
+  description: string;
+  bodyType?: string;
+  transmission?: string;
+  drivetrain?: string;
+  fuelType?: string;
+  exteriorColor?: string;
+  interiorColor?: string;
+  features: string[];
+  photos: ListingMedia[];
+  inspection?: ListingInspection;
+  seller: ListingSeller;
+  relatedListingIds: string[];
+};
+
+export type ListingsData = {
+  version: string;
+  listings: ListingDetail[];
+};

--- a/data/categories.json
+++ b/data/categories.json
@@ -1,0 +1,180 @@
+{
+  "version": "2024-06-01",
+  "categories": [
+    {
+      "slug": "vehicles",
+      "label": "Vehicles",
+      "description": "Cars, motorcycles, commercial vehicles, and parts trusted by Saudi buyers.",
+      "icon": "car",
+      "featuredFilters": ["brand", "model", "condition"],
+      "children": [
+        {
+          "slug": "cars",
+          "label": "Cars",
+          "description": "Sedans, SUVs, coupes, and pickups for every lifestyle.",
+          "children": [
+            { "slug": "sedan", "label": "Sedan" },
+            { "slug": "suv", "label": "SUV" },
+            { "slug": "coupe", "label": "Coupe" },
+            { "slug": "hatchback", "label": "Hatchback" },
+            { "slug": "pickup", "label": "Pickup" }
+          ]
+        },
+        {
+          "slug": "motorcycles",
+          "label": "Motorcycles",
+          "description": "Street, cruiser, and off-road bikes.",
+          "children": [
+            { "slug": "street", "label": "Street" },
+            { "slug": "cruiser", "label": "Cruiser" },
+            { "slug": "off-road", "label": "Off-Road" },
+            { "slug": "scooter", "label": "Scooter" }
+          ]
+        },
+        {
+          "slug": "commercial-vehicles",
+          "label": "Commercial Vehicles",
+          "description": "Fleet vans, buses, and trucks.",
+          "children": [
+            { "slug": "vans", "label": "Vans" },
+            { "slug": "buses", "label": "Buses" },
+            { "slug": "trucks", "label": "Trucks" }
+          ]
+        },
+        {
+          "slug": "parts-accessories",
+          "label": "Parts & Accessories",
+          "description": "OEM and aftermarket parts, electronics, and tires.",
+          "children": [
+            { "slug": "engines", "label": "Engines" },
+            { "slug": "body-parts", "label": "Body Parts" },
+            { "slug": "tires", "label": "Tires & Wheels" },
+            { "slug": "electronics", "label": "Electronics" }
+          ]
+        },
+        {
+          "slug": "marine",
+          "label": "Marine",
+          "description": "Boats, jet skis, and trailers.",
+          "children": [
+            { "slug": "boats", "label": "Boats" },
+            { "slug": "jet-skis", "label": "Jet Skis" },
+            { "slug": "trailers", "label": "Trailers" }
+          ]
+        }
+      ]
+    },
+    {
+      "slug": "real-estate",
+      "label": "Real Estate",
+      "description": "Residential, commercial, and land listings across the Kingdom.",
+      "icon": "building",
+      "featuredFilters": ["property_type", "location_city", "price_range"],
+      "children": [
+        { "slug": "residential-sales", "label": "Residential Sales" },
+        { "slug": "residential-rentals", "label": "Residential Rentals" },
+        { "slug": "commercial", "label": "Commercial" },
+        { "slug": "land-plots", "label": "Land & Plots" },
+        { "slug": "coliving-shared", "label": "Co-living & Shared" }
+      ]
+    },
+    {
+      "slug": "luxury",
+      "label": "Luxury",
+      "description": "Premium watches, jewelry, and collectibles.",
+      "icon": "gem",
+      "featuredFilters": ["brand", "authenticity_docs", "condition"],
+      "children": [
+        { "slug": "watches", "label": "Watches" },
+        { "slug": "jewelry", "label": "Jewelry" },
+        { "slug": "designer-bags", "label": "Designer Bags" },
+        { "slug": "collectibles", "label": "Collectibles" },
+        { "slug": "luxury-autos", "label": "Luxury Autos" }
+      ]
+    },
+    {
+      "slug": "electronics",
+      "label": "Electronics",
+      "description": "Mobiles, computers, gaming, and smart devices.",
+      "icon": "device",
+      "featuredFilters": ["brand", "model", "condition"],
+      "children": [
+        { "slug": "mobile-phones", "label": "Mobile Phones" },
+        { "slug": "laptops-computers", "label": "Laptops & Computers" },
+        { "slug": "home-entertainment", "label": "Home Entertainment" },
+        { "slug": "smart-home", "label": "Smart Home" },
+        { "slug": "gaming", "label": "Gaming" }
+      ]
+    },
+    {
+      "slug": "home-and-living",
+      "label": "Home & Living",
+      "description": "Furniture, appliances, and décor.",
+      "icon": "home",
+      "featuredFilters": ["material", "color", "condition"],
+      "children": [
+        { "slug": "furniture", "label": "Furniture" },
+        { "slug": "appliances", "label": "Appliances" },
+        { "slug": "kitchen-dining", "label": "Kitchen & Dining" },
+        { "slug": "home-decor", "label": "Home Décor" },
+        { "slug": "outdoor-garden", "label": "Outdoor & Garden" }
+      ]
+    },
+    {
+      "slug": "fashion",
+      "label": "Fashion",
+      "description": "Apparel and accessories for every occasion.",
+      "icon": "wardrobe",
+      "featuredFilters": ["size", "brand", "condition"],
+      "children": [
+        { "slug": "men", "label": "Men" },
+        { "slug": "women", "label": "Women" },
+        { "slug": "kids", "label": "Kids" },
+        { "slug": "luxury-fashion", "label": "Luxury Fashion" },
+        { "slug": "traditional-wear", "label": "Traditional Wear" }
+      ]
+    },
+    {
+      "slug": "sports-and-outdoors",
+      "label": "Sports & Outdoors",
+      "description": "Gear for fitness, adventure, and leisure.",
+      "icon": "fitness",
+      "featuredFilters": ["equipment_type", "condition", "usage_level"],
+      "children": [
+        { "slug": "fitness-equipment", "label": "Fitness Equipment" },
+        { "slug": "team-sports", "label": "Team Sports" },
+        { "slug": "outdoor-adventure", "label": "Outdoor Adventure" },
+        { "slug": "cycling", "label": "Cycling" },
+        { "slug": "water-sports", "label": "Water Sports" }
+      ]
+    },
+    {
+      "slug": "business-and-industrial",
+      "label": "Business & Industrial",
+      "description": "Machinery, tools, and wholesale supplies.",
+      "icon": "factory",
+      "featuredFilters": ["power_requirement", "usage_hours", "location_city"],
+      "children": [
+        { "slug": "heavy-machinery", "label": "Heavy Machinery" },
+        { "slug": "tools-hardware", "label": "Tools & Hardware" },
+        { "slug": "office-equipment", "label": "Office Equipment" },
+        { "slug": "industrial-supplies", "label": "Industrial Supplies" },
+        { "slug": "wholesale-lots", "label": "Wholesale Lots" }
+      ]
+    },
+    {
+      "slug": "services",
+      "label": "Services",
+      "description": "Professional and household services with city coverage.",
+      "icon": "handshake",
+      "featuredFilters": ["service_type", "coverage_city", "availability"],
+      "children": [
+        { "slug": "automotive-services", "label": "Automotive Services" },
+        { "slug": "home-services", "label": "Home Services" },
+        { "slug": "professional-services", "label": "Professional Services" },
+        { "slug": "events-catering", "label": "Events & Catering" },
+        { "slug": "logistics-delivery", "label": "Logistics & Delivery" }
+      ]
+    }
+  ]
+}

--- a/data/filters.json
+++ b/data/filters.json
@@ -1,0 +1,80 @@
+{
+  "version": "2024-06-01",
+  "filters": {
+    "vehicles": [
+      { "key": "brand", "type": "select", "source": "vehicles.brands" },
+      { "key": "model", "type": "select", "source": "vehicles.models", "dependsOn": "brand" },
+      { "key": "year", "type": "range", "min": 1990, "max": 2026 },
+      { "key": "trim", "type": "select", "source": "vehicles.trims", "dependsOn": "model" },
+      { "key": "condition", "type": "segmented", "options": ["new", "used"], "default": "used" },
+      { "key": "mileage", "type": "range", "unit": "km", "visibleWhen": { "condition": "used" } },
+      { "key": "owners", "type": "number", "min": 1, "max": 5, "visibleWhen": { "condition": "used" } },
+      { "key": "accident_history", "type": "select", "options": ["no-accidents", "minor", "major"], "visibleWhen": { "condition": "used" } },
+      { "key": "warranty_status", "type": "select", "options": ["manufacturer", "extended", "none"], "visibleWhen": { "condition": "used" } },
+      { "key": "city", "type": "select", "options": ["riyadh", "jeddah", "dammam", "makkah", "medina"] }
+    ],
+    "real-estate": [
+      { "key": "property_type", "type": "select", "options": ["villa", "apartment", "townhouse", "compound", "plot"] },
+      { "key": "location_city", "type": "select", "options": ["riyadh", "jeddah", "dammam", "khobar", "makkah"] },
+      { "key": "price_range", "type": "range", "min": 50000, "max": 10000000, "unit": "sar" },
+      { "key": "bedrooms", "type": "number", "min": 1, "max": 10 },
+      { "key": "bathrooms", "type": "number", "min": 1, "max": 10 },
+      { "key": "area_sqm", "type": "range", "min": 50, "max": 2000, "unit": "sqm" },
+      { "key": "furnished", "type": "segmented", "options": ["yes", "no", "partially"] },
+      { "key": "available_from", "type": "date" },
+      { "key": "deed_verified", "type": "segmented", "options": ["verified", "pending"] }
+    ],
+    "luxury": [
+      { "key": "brand", "type": "select", "options": ["rolex", "patek-philippe", "cartier", "hermes", "louis-vuitton"] },
+      { "key": "condition", "type": "segmented", "options": ["new", "like-new", "excellent", "good"] },
+      { "key": "authenticity_docs", "type": "segmented", "options": ["certificate", "invoice", "none"] },
+      { "key": "year_of_purchase", "type": "range", "min": 1990, "max": 2024 },
+      { "key": "price_range", "type": "range", "min": 1000, "max": 500000, "unit": "sar" }
+    ],
+    "electronics": [
+      { "key": "category", "type": "select", "options": ["mobile", "laptop", "tablet", "tv", "gaming-console"] },
+      { "key": "brand", "type": "select", "options": ["apple", "samsung", "huawei", "lenovo", "sony", "microsoft"] },
+      { "key": "model", "type": "text" },
+      { "key": "storage_size", "type": "select", "options": ["64gb", "128gb", "256gb", "512gb", "1tb"] },
+      { "key": "condition", "type": "segmented", "options": ["new", "open-box", "used"] },
+      { "key": "warranty_remaining", "type": "number", "unit": "months" },
+      { "key": "price_range", "type": "range", "min": 200, "max": 20000, "unit": "sar" }
+    ],
+    "home-and-living": [
+      { "key": "subcategory", "type": "select", "options": ["furniture", "appliances", "kitchen", "decor", "outdoor"] },
+      { "key": "material", "type": "select", "options": ["wood", "metal", "leather", "fabric", "stone"] },
+      { "key": "color", "type": "select", "options": ["neutral", "dark", "light", "bold"] },
+      { "key": "condition", "type": "segmented", "options": ["new", "like-new", "used"] },
+      { "key": "dimension_notes", "type": "text" }
+    ],
+    "fashion": [
+      { "key": "gender", "type": "segmented", "options": ["men", "women", "kids", "unisex"] },
+      { "key": "size", "type": "select", "options": ["xs", "s", "m", "l", "xl", "xxl"] },
+      { "key": "brand", "type": "select", "options": ["gucci", "dior", "abercrombie", "namshi", "local-designer"] },
+      { "key": "condition", "type": "segmented", "options": ["new", "like-new", "gently-used"] },
+      { "key": "authenticity_docs", "type": "segmented", "options": ["certificate", "receipt", "none"] }
+    ],
+    "sports-and-outdoors": [
+      { "key": "equipment_type", "type": "select", "options": ["fitness", "team-sports", "outdoor", "cycling", "water"] },
+      { "key": "brand", "type": "select", "options": ["adidas", "nike", "decathlon", "giant", "specialized"] },
+      { "key": "condition", "type": "segmented", "options": ["new", "like-new", "used"] },
+      { "key": "usage_level", "type": "select", "options": ["beginner", "intermediate", "advanced"] },
+      { "key": "city", "type": "select", "options": ["riyadh", "jeddah", "dammam", "abha"] }
+    ],
+    "business-and-industrial": [
+      { "key": "category", "type": "select", "options": ["machinery", "tools", "office", "industrial", "wholesale"] },
+      { "key": "brand", "type": "text" },
+      { "key": "condition", "type": "segmented", "options": ["new", "refurbished", "used"] },
+      { "key": "power_requirement", "type": "text" },
+      { "key": "usage_hours", "type": "number", "visibleWhen": { "condition": "used" } },
+      { "key": "location_city", "type": "select", "options": ["riyadh", "jeddah", "jubail", "yanbu"] }
+    ],
+    "services": [
+      { "key": "service_type", "type": "select", "options": ["automotive", "home", "professional", "events", "logistics"] },
+      { "key": "coverage_city", "type": "select", "options": ["riyadh", "jeddah", "dammam", "medina", "makkah"] },
+      { "key": "availability", "type": "segmented", "options": ["weekdays", "weekends", "24-7"] },
+      { "key": "pricing_model", "type": "select", "options": ["fixed", "hourly", "quote"] },
+      { "key": "certifications", "type": "text" }
+    ]
+  }
+}

--- a/data/i18n/ar.json
+++ b/data/i18n/ar.json
@@ -1,0 +1,24 @@
+{
+  "common": {
+    "siteName": "مزاد.كوم",
+    "tagline": "منصة المزادات الموثوقة في السعودية",
+    "language": "العربية"
+  },
+  "navigation": {
+    "categories": "التصنيفات",
+    "searchPlaceholder": "ابحث في مزاد...",
+    "sell": "بيع",
+    "login": "تسجيل الدخول"
+  },
+  "categories": {
+    "vehicles": "مركبات",
+    "real-estate": "عقار",
+    "luxury": "فاخر",
+    "electronics": "إلكترونيات",
+    "home-and-living": "المنزل والمعيشة",
+    "fashion": "أزياء",
+    "sports-and-outdoors": "الرياضة والهواء الطلق",
+    "business-and-industrial": "أعمال وصناعة",
+    "services": "خدمات"
+  }
+}

--- a/data/i18n/en.json
+++ b/data/i18n/en.json
@@ -1,0 +1,24 @@
+{
+  "common": {
+    "siteName": "Mazad.com",
+    "tagline": "Saudi Marketplace for Trusted Auctions",
+    "language": "English"
+  },
+  "navigation": {
+    "categories": "Categories",
+    "searchPlaceholder": "Search Mazad...",
+    "sell": "Sell",
+    "login": "Sign In"
+  },
+  "categories": {
+    "vehicles": "Vehicles",
+    "real-estate": "Real Estate",
+    "luxury": "Luxury",
+    "electronics": "Electronics",
+    "home-and-living": "Home & Living",
+    "fashion": "Fashion",
+    "sports-and-outdoors": "Sports & Outdoors",
+    "business-and-industrial": "Business & Industrial",
+    "services": "Services"
+  }
+}

--- a/data/listings.json
+++ b/data/listings.json
@@ -1,0 +1,415 @@
+{
+  "version": "2024-06-15",
+  "listings": [
+    {
+      "id": "listing-land-cruiser",
+      "title": "2023 Toyota Land Cruiser VXR",
+      "categorySlug": "vehicles",
+      "subcategorySlug": "cars",
+      "brandSlug": "toyota",
+      "brandLabel": "Toyota",
+      "modelSlug": "land-cruiser",
+      "modelLabel": "Land Cruiser",
+      "year": 2023,
+      "trim": "vxr",
+      "trimLabel": "VXR",
+      "bodyType": "SUV",
+      "transmission": "10-speed Automatic",
+      "drivetrain": "4WD",
+      "fuelType": "Petrol",
+      "exteriorColor": "Pearl White",
+      "interiorColor": "Tan Leather",
+      "priceSar": 412000,
+      "city": "Riyadh",
+      "citySlug": "riyadh",
+      "condition": "used",
+      "mileageKm": 18000,
+      "certified": true,
+      "owners": 1,
+      "accidentHistory": "no-accidents",
+      "warrantyStatus": "manufacturer",
+      "description": "Flagship SUV with dealership service history, one owner, and Mazad Certified inspection completed in May 2024.",
+      "features": [
+        "Adaptive Cruise Control",
+        "360° Camera",
+        "Ventilated Seats",
+        "Apple CarPlay",
+        "Front & Rear Parking Sensors"
+      ],
+      "photos": [
+        { "id": "front-angle", "caption": "Exterior front angle" },
+        { "id": "interior", "caption": "Cabin overview" },
+        { "id": "rear", "caption": "Rear profile" }
+      ],
+      "inspection": {
+        "certified": true,
+        "inspectionDate": "2024-05-12",
+        "inspector": "Najm Inspections",
+        "summary": "Vehicle passed 210-point checklist with no major findings.",
+        "checklist": [
+          { "item": "Exterior body", "status": "pass" },
+          { "item": "Interior condition", "status": "pass" },
+          { "item": "Mechanical systems", "status": "pass" },
+          { "item": "Service records", "status": "pass" }
+        ]
+      },
+      "seller": {
+        "name": "Elite Motors KSA",
+        "rating": 4.9,
+        "totalSales": 128,
+        "responseTime": "Under 1 hour",
+        "verified": true
+      },
+      "relatedListingIds": [
+        "listing-prado-signature",
+        "listing-hilux-gr",
+        "listing-camry-limited",
+        "listing-rav4-hybrid"
+      ]
+    },
+    {
+      "id": "listing-prado-signature",
+      "title": "2022 Toyota Land Cruiser Prado Signature",
+      "categorySlug": "vehicles",
+      "subcategorySlug": "cars",
+      "brandSlug": "toyota",
+      "brandLabel": "Toyota",
+      "modelSlug": "land-cruiser-prado",
+      "modelLabel": "Land Cruiser Prado",
+      "year": 2022,
+      "trim": "signature",
+      "trimLabel": "Signature",
+      "bodyType": "SUV",
+      "transmission": "6-speed Automatic",
+      "drivetrain": "4WD",
+      "fuelType": "Petrol",
+      "exteriorColor": "Graphite Grey",
+      "interiorColor": "Beige Leather",
+      "priceSar": 265000,
+      "city": "Jeddah",
+      "citySlug": "jeddah",
+      "condition": "used",
+      "mileageKm": 32000,
+      "certified": true,
+      "owners": 1,
+      "accidentHistory": "no-accidents",
+      "warrantyStatus": "extended",
+      "description": "Well-maintained Prado with full off-road package and Mazad Certified status.",
+      "features": [
+        "KDSS Suspension",
+        "Rear Entertainment",
+        "Leather Seating",
+        "Multi-terrain Select"
+      ],
+      "photos": [
+        { "id": "side", "caption": "Side profile" },
+        { "id": "dashboard", "caption": "Dashboard controls" }
+      ],
+      "inspection": {
+        "certified": true,
+        "inspectionDate": "2024-04-28",
+        "inspector": "Najm Inspections",
+        "summary": "Minor wear on tires noted; recommendation to rotate.",
+        "checklist": [
+          { "item": "Tire tread", "status": "attention", "notes": "Rotate within 5,000 km" },
+          { "item": "Braking system", "status": "pass" },
+          { "item": "Suspension", "status": "pass" }
+        ]
+      },
+      "seller": {
+        "name": "Elite Motors KSA",
+        "rating": 4.9,
+        "totalSales": 128,
+        "responseTime": "Under 1 hour",
+        "verified": true
+      },
+      "relatedListingIds": [
+        "listing-land-cruiser",
+        "listing-hilux-gr",
+        "listing-camry-limited",
+        "listing-rav4-hybrid"
+      ]
+    },
+    {
+      "id": "listing-hilux-gr",
+      "title": "2024 Toyota Hilux GR Sport",
+      "categorySlug": "vehicles",
+      "subcategorySlug": "cars",
+      "brandSlug": "toyota",
+      "brandLabel": "Toyota",
+      "modelSlug": "hilux",
+      "modelLabel": "Hilux",
+      "year": 2024,
+      "trim": "gr-sport",
+      "trimLabel": "GR Sport",
+      "bodyType": "Pickup",
+      "transmission": "6-speed Automatic",
+      "drivetrain": "4WD",
+      "fuelType": "Diesel",
+      "exteriorColor": "Emotional Red",
+      "interiorColor": "Black Fabric",
+      "priceSar": 189000,
+      "city": "Dammam",
+      "citySlug": "dammam",
+      "condition": "new",
+      "certified": false,
+      "owners": 0,
+      "accidentHistory": "no-accidents",
+      "warrantyStatus": "manufacturer",
+      "description": "Brand new Hilux GR Sport with delivery mileage and full warranty.",
+      "features": [
+        "GR Sport Styling",
+        "Rear Differential Lock",
+        "LED Headlights",
+        "Smart Entry"
+      ],
+      "photos": [
+        { "id": "front", "caption": "Front fascia" },
+        { "id": "bed", "caption": "Cargo bed" }
+      ],
+      "inspection": {
+        "certified": false,
+        "summary": "Eligible for Mazad Certified inspection upon request.",
+        "checklist": []
+      },
+      "seller": {
+        "name": "Elite Motors KSA",
+        "rating": 4.9,
+        "totalSales": 128,
+        "responseTime": "Under 1 hour",
+        "verified": true
+      },
+      "relatedListingIds": [
+        "listing-land-cruiser",
+        "listing-prado-signature",
+        "listing-camry-limited",
+        "listing-rav4-hybrid"
+      ]
+    },
+    {
+      "id": "listing-camry-limited",
+      "title": "2023 Toyota Camry Limited",
+      "categorySlug": "vehicles",
+      "subcategorySlug": "cars",
+      "brandSlug": "toyota",
+      "brandLabel": "Toyota",
+      "modelSlug": "camry",
+      "modelLabel": "Camry",
+      "year": 2023,
+      "trim": "limited",
+      "trimLabel": "Limited",
+      "bodyType": "Sedan",
+      "transmission": "8-speed Automatic",
+      "drivetrain": "FWD",
+      "fuelType": "Hybrid",
+      "exteriorColor": "Midnight Black",
+      "interiorColor": "Cream Leather",
+      "priceSar": 135000,
+      "city": "Riyadh",
+      "citySlug": "riyadh",
+      "condition": "used",
+      "mileageKm": 22000,
+      "certified": false,
+      "owners": 1,
+      "accidentHistory": "minor",
+      "warrantyStatus": "manufacturer",
+      "description": "Camry Limited hybrid with comprehensive service records and advanced safety suite.",
+      "features": [
+        "Toyota Safety Sense",
+        "Panoramic Roof",
+        "Heated Seats",
+        "Wireless Charging"
+      ],
+      "photos": [
+        { "id": "front-quarter", "caption": "Front quarter view" },
+        { "id": "infotainment", "caption": "Infotainment system" }
+      ],
+      "inspection": {
+        "certified": false,
+        "summary": "Minor bumper repaint disclosed; eligible for Mazad Certified inspection.",
+        "checklist": []
+      },
+      "seller": {
+        "name": "Elite Motors KSA",
+        "rating": 4.9,
+        "totalSales": 128,
+        "responseTime": "Under 1 hour",
+        "verified": true
+      },
+      "relatedListingIds": [
+        "listing-land-cruiser",
+        "listing-prado-signature",
+        "listing-hilux-gr",
+        "listing-rav4-hybrid"
+      ]
+    },
+    {
+      "id": "listing-rav4-hybrid",
+      "title": "2024 Toyota RAV4 Hybrid XLE",
+      "categorySlug": "vehicles",
+      "subcategorySlug": "cars",
+      "brandSlug": "toyota",
+      "brandLabel": "Toyota",
+      "modelSlug": "rav4",
+      "modelLabel": "RAV4",
+      "year": 2024,
+      "trim": "xle",
+      "trimLabel": "XLE",
+      "bodyType": "SUV",
+      "transmission": "CVT",
+      "drivetrain": "AWD",
+      "fuelType": "Hybrid",
+      "exteriorColor": "Lunar Rock",
+      "interiorColor": "Black Fabric",
+      "priceSar": 155000,
+      "city": "Khobar",
+      "citySlug": "khobar",
+      "condition": "new",
+      "certified": false,
+      "owners": 0,
+      "accidentHistory": "no-accidents",
+      "warrantyStatus": "manufacturer",
+      "description": "Dealer allocation RAV4 Hybrid with delivery mileage and Toyota warranty.",
+      "features": [
+        "Hybrid Synergy Drive",
+        "Power Tailgate",
+        "Blind Spot Monitor",
+        "Dual-zone Climate"
+      ],
+      "photos": [
+        { "id": "front", "caption": "Front view" },
+        { "id": "cargo", "caption": "Cargo space" }
+      ],
+      "inspection": {
+        "certified": false,
+        "summary": "Pre-delivery inspection completed by dealer.",
+        "checklist": []
+      },
+      "seller": {
+        "name": "Elite Motors KSA",
+        "rating": 4.9,
+        "totalSales": 128,
+        "responseTime": "Under 1 hour",
+        "verified": true
+      },
+      "relatedListingIds": [
+        "listing-land-cruiser",
+        "listing-prado-signature",
+        "listing-hilux-gr",
+        "listing-camry-limited"
+      ]
+    },
+    {
+      "id": "listing-gle",
+      "title": "2024 Mercedes-Benz GLE 450",
+      "categorySlug": "vehicles",
+      "subcategorySlug": "cars",
+      "brandSlug": "mercedes-benz",
+      "brandLabel": "Mercedes-Benz",
+      "modelSlug": "gle-450",
+      "modelLabel": "GLE 450",
+      "year": 2024,
+      "trim": "amg-line",
+      "trimLabel": "AMG Line",
+      "bodyType": "SUV",
+      "transmission": "9-speed Automatic",
+      "drivetrain": "AWD",
+      "fuelType": "Mild Hybrid",
+      "exteriorColor": "Obsidian Black",
+      "interiorColor": "Black Nappa Leather",
+      "priceSar": 520000,
+      "city": "Jeddah",
+      "citySlug": "jeddah",
+      "condition": "new",
+      "certified": false,
+      "owners": 0,
+      "accidentHistory": "no-accidents",
+      "warrantyStatus": "manufacturer",
+      "description": "Brand new GLE 450 AMG Line with technology and premium plus packages.",
+      "features": [
+        "MBUX Hyperscreen",
+        "Air Suspension",
+        "Burmester Audio",
+        "Heads-up Display"
+      ],
+      "photos": [
+        { "id": "interior", "caption": "Nappa leather interior" },
+        { "id": "wheel", "caption": "AMG alloy wheels" }
+      ],
+      "inspection": {
+        "certified": false,
+        "summary": "Eligible for Mazad Certified program post 1,000 km.",
+        "checklist": []
+      },
+      "seller": {
+        "name": "Prestige Autos",
+        "rating": 4.7,
+        "totalSales": 87,
+        "responseTime": "Within 2 hours",
+        "verified": true
+      },
+      "relatedListingIds": [
+        "listing-land-cruiser",
+        "listing-prado-signature",
+        "listing-hilux-gr",
+        "listing-camry-limited"
+      ]
+    },
+    {
+      "id": "listing-cerato",
+      "title": "2024 Kia Cerato GT Line",
+      "categorySlug": "vehicles",
+      "subcategorySlug": "cars",
+      "brandSlug": "kia",
+      "brandLabel": "Kia",
+      "modelSlug": "cerato",
+      "modelLabel": "Cerato",
+      "year": 2024,
+      "trim": "gt-line",
+      "trimLabel": "GT Line",
+      "bodyType": "Sedan",
+      "transmission": "IVT",
+      "drivetrain": "FWD",
+      "fuelType": "Petrol",
+      "exteriorColor": "Snow White Pearl",
+      "interiorColor": "Black & Red",
+      "priceSar": 98000,
+      "city": "Dammam",
+      "citySlug": "dammam",
+      "condition": "new",
+      "certified": false,
+      "owners": 0,
+      "accidentHistory": "no-accidents",
+      "warrantyStatus": "manufacturer",
+      "description": "Sporty Cerato GT Line with two-tone interior and ADAS suite.",
+      "features": [
+        "Lane Keeping Assist",
+        "Sunroof",
+        "Wireless Charger",
+        "Rear Cross Traffic Alert"
+      ],
+      "photos": [
+        { "id": "front", "caption": "Front fascia" },
+        { "id": "interior", "caption": "Two-tone seats" }
+      ],
+      "inspection": {
+        "certified": false,
+        "summary": "Eligible for Mazad Certified inspection after 5,000 km.",
+        "checklist": []
+      },
+      "seller": {
+        "name": "Eastern Auto Gallery",
+        "rating": 4.6,
+        "totalSales": 64,
+        "responseTime": "Within 4 hours",
+        "verified": true
+      },
+      "relatedListingIds": [
+        "listing-hilux-gr",
+        "listing-camry-limited",
+        "listing-rav4-hybrid",
+        "listing-land-cruiser"
+      ]
+    }
+  ]
+}

--- a/data/vehicles/brands.csv
+++ b/data/vehicles/brands.csv
@@ -1,0 +1,9 @@
+brand,label,origin,popular_in_ksa
+toyota,Toyota,Japan,true
+nissan,Nissan,Japan,true
+hyundai,Hyundai,South Korea,true
+kia,Kia,South Korea,true
+ford,Ford,USA,true
+lexus,Lexus,Japan,true
+bmw,BMW,Germany,true
+mercedes-benz,Mercedes-Benz,Germany,true

--- a/data/vehicles/models.csv
+++ b/data/vehicles/models.csv
@@ -1,0 +1,18 @@
+brand,model,label,body_type,year_start,year_end
+toyota,land-cruiser,Land Cruiser,SUV,2016,2024
+toyota,camry,Camry,Sedan,2014,2024
+toyota,corolla,Corolla,Sedan,2015,2024
+nissan,patrol,Patrol,SUV,2015,2024
+nissan,x-trail,X-Trail,SUV,2014,2024
+hyundai,sonata,Sonata,Sedan,2015,2024
+hyundai,tucson,Tucson,SUV,2015,2024
+kia,cerato,Cerato,Sedan,2016,2024
+kia,sportage,Sportage,SUV,2016,2024
+ford,f-150,F-150,Pickup,2015,2024
+ford,expedition,Expedition,SUV,2015,2024
+lexus,lx,LX,SUV,2016,2024
+lexus,es,ES,Sedan,2016,2024
+bmw,series-5,5 Series,Sedan,2016,2024
+bmw,x5,X5,SUV,2016,2024
+mercedes-benz,e-class,E-Class,Sedan,2016,2024
+mercedes-benz,gle,GLE,SUV,2016,2024

--- a/data/vehicles/trims.csv
+++ b/data/vehicles/trims.csv
@@ -1,0 +1,26 @@
+brand,model,trim,trim_label,year,engine,drivetrain,transmission,fuel
+toyota,land-cruiser,gxr-v6,GXR V6,2024,4.0L V6,4WD,Automatic,Petrol
+toyota,land-cruiser,vxr-v8,VXR V8,2024,5.7L V8,4WD,Automatic,Petrol
+toyota,land-cruiser,exr,EXR,2023,4.0L V6,4WD,Automatic,Petrol
+toyota,camry,se,SE,2024,2.5L I4,FWD,Automatic,Petrol
+toyota,camry,xse,XSE,2023,3.5L V6,FWD,Automatic,Petrol
+toyota,corolla,le,LE,2024,1.8L I4,FWD,Automatic,Petrol
+toyota,corolla,hybrid,Hybrid,2023,1.8L Hybrid,FWD,Automatic,Hybrid
+nissan,patrol,se-titanium,SE Titanium,2024,5.6L V8,4WD,Automatic,Petrol
+nissan,patrol,le-platinum,LE Platinum,2023,5.6L V8,4WD,Automatic,Petrol
+nissan,x-trail,sv,SV,2024,2.5L I4,AWD,Automatic,Petrol
+hyundai,sonata,smart,Smart,2024,2.5L I4,FWD,Automatic,Petrol
+hyundai,sonata,hybrid,Hybrid,2023,2.0L Hybrid,FWD,Automatic,Hybrid
+hyundai,tucson,gls,GLS,2024,2.5L I4,AWD,Automatic,Petrol
+kia,cerato,ex,EX,2024,2.0L I4,FWD,Automatic,Petrol
+kia,cerato,gt-line,GT Line,2023,1.6L Turbo,FWD,Automatic,Petrol
+kia,sportage,gt,GT,2024,1.6L Turbo,AWD,Automatic,Petrol
+ford,f-150,lariet,Lariat,2024,3.5L EcoBoost,4WD,Automatic,Petrol
+ford,f-150,platinum,Platinum,2023,5.0L V8,4WD,Automatic,Petrol
+ford,expedition,limited,Limited,2024,3.5L EcoBoost,4WD,Automatic,Petrol
+lexus,lx,600-signature,600 Signature,2024,3.5L Twin-Turbo V6,4WD,Automatic,Petrol
+lexus,es,350-premier,350 Premier,2024,3.5L V6,FWD,Automatic,Petrol
+bmw,series-5,530i,530i,2024,2.0L Turbo,RWD,Automatic,Petrol
+bmw,x5,xdrive40i,xDrive40i,2024,3.0L Turbo,AWD,Automatic,Petrol
+mercedes-benz,e-class,e200,E 200,2024,2.0L Turbo,RWD,Automatic,Petrol
+mercedes-benz,gle,gle450,GLE 450,2024,3.0L Turbo,AWD,Automatic,Petrol

--- a/data/vehicles/vehicles.json
+++ b/data/vehicles/vehicles.json
@@ -1,0 +1,974 @@
+{
+  "version": "2024-06-01",
+  "generatedAt": "2025-09-20T18:59:42.482Z",
+  "brands": [
+    {
+      "brand": "toyota",
+      "label": "Toyota",
+      "origin": "Japan",
+      "popularInKsa": true,
+      "models": [
+        {
+          "model": "camry",
+          "label": "Camry",
+          "bodyType": "Sedan",
+          "year_min": 2014,
+          "year_max": 2024,
+          "trims": [
+            {
+              "trim": "se",
+              "label": "SE",
+              "engine": "2.5L I4",
+              "drivetrain": "FWD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2024
+              ]
+            },
+            {
+              "trim": "xse",
+              "label": "XSE",
+              "engine": "3.5L V6",
+              "drivetrain": "FWD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2023
+              ]
+            }
+          ],
+          "condition": {
+            "options": [
+              "new",
+              "used"
+            ],
+            "usedOnlyAttributes": [
+              {
+                "key": "mileage_km",
+                "label": "Mileage (km)"
+              },
+              {
+                "key": "owners_count",
+                "label": "Number of owners"
+              },
+              {
+                "key": "accident_history",
+                "label": "Accident history"
+              },
+              {
+                "key": "warranty_status",
+                "label": "Warranty status"
+              },
+              {
+                "key": "service_history",
+                "label": "Service history"
+              }
+            ]
+          }
+        },
+        {
+          "model": "corolla",
+          "label": "Corolla",
+          "bodyType": "Sedan",
+          "year_min": 2015,
+          "year_max": 2024,
+          "trims": [
+            {
+              "trim": "le",
+              "label": "LE",
+              "engine": "1.8L I4",
+              "drivetrain": "FWD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2024
+              ]
+            },
+            {
+              "trim": "hybrid",
+              "label": "Hybrid",
+              "engine": "1.8L Hybrid",
+              "drivetrain": "FWD",
+              "transmission": "Automatic",
+              "fuel": "Hybrid",
+              "years": [
+                2023
+              ]
+            }
+          ],
+          "condition": {
+            "options": [
+              "new",
+              "used"
+            ],
+            "usedOnlyAttributes": [
+              {
+                "key": "mileage_km",
+                "label": "Mileage (km)"
+              },
+              {
+                "key": "owners_count",
+                "label": "Number of owners"
+              },
+              {
+                "key": "accident_history",
+                "label": "Accident history"
+              },
+              {
+                "key": "warranty_status",
+                "label": "Warranty status"
+              },
+              {
+                "key": "service_history",
+                "label": "Service history"
+              }
+            ]
+          }
+        },
+        {
+          "model": "land-cruiser",
+          "label": "Land Cruiser",
+          "bodyType": "SUV",
+          "year_min": 2016,
+          "year_max": 2024,
+          "trims": [
+            {
+              "trim": "gxr-v6",
+              "label": "GXR V6",
+              "engine": "4.0L V6",
+              "drivetrain": "4WD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2024
+              ]
+            },
+            {
+              "trim": "vxr-v8",
+              "label": "VXR V8",
+              "engine": "5.7L V8",
+              "drivetrain": "4WD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2024
+              ]
+            },
+            {
+              "trim": "exr",
+              "label": "EXR",
+              "engine": "4.0L V6",
+              "drivetrain": "4WD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2023
+              ]
+            }
+          ],
+          "condition": {
+            "options": [
+              "new",
+              "used"
+            ],
+            "usedOnlyAttributes": [
+              {
+                "key": "mileage_km",
+                "label": "Mileage (km)"
+              },
+              {
+                "key": "owners_count",
+                "label": "Number of owners"
+              },
+              {
+                "key": "accident_history",
+                "label": "Accident history"
+              },
+              {
+                "key": "warranty_status",
+                "label": "Warranty status"
+              },
+              {
+                "key": "service_history",
+                "label": "Service history"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "brand": "nissan",
+      "label": "Nissan",
+      "origin": "Japan",
+      "popularInKsa": true,
+      "models": [
+        {
+          "model": "patrol",
+          "label": "Patrol",
+          "bodyType": "SUV",
+          "year_min": 2015,
+          "year_max": 2024,
+          "trims": [
+            {
+              "trim": "se-titanium",
+              "label": "SE Titanium",
+              "engine": "5.6L V8",
+              "drivetrain": "4WD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2024
+              ]
+            },
+            {
+              "trim": "le-platinum",
+              "label": "LE Platinum",
+              "engine": "5.6L V8",
+              "drivetrain": "4WD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2023
+              ]
+            }
+          ],
+          "condition": {
+            "options": [
+              "new",
+              "used"
+            ],
+            "usedOnlyAttributes": [
+              {
+                "key": "mileage_km",
+                "label": "Mileage (km)"
+              },
+              {
+                "key": "owners_count",
+                "label": "Number of owners"
+              },
+              {
+                "key": "accident_history",
+                "label": "Accident history"
+              },
+              {
+                "key": "warranty_status",
+                "label": "Warranty status"
+              },
+              {
+                "key": "service_history",
+                "label": "Service history"
+              }
+            ]
+          }
+        },
+        {
+          "model": "x-trail",
+          "label": "X-Trail",
+          "bodyType": "SUV",
+          "year_min": 2014,
+          "year_max": 2024,
+          "trims": [
+            {
+              "trim": "sv",
+              "label": "SV",
+              "engine": "2.5L I4",
+              "drivetrain": "AWD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2024
+              ]
+            }
+          ],
+          "condition": {
+            "options": [
+              "new",
+              "used"
+            ],
+            "usedOnlyAttributes": [
+              {
+                "key": "mileage_km",
+                "label": "Mileage (km)"
+              },
+              {
+                "key": "owners_count",
+                "label": "Number of owners"
+              },
+              {
+                "key": "accident_history",
+                "label": "Accident history"
+              },
+              {
+                "key": "warranty_status",
+                "label": "Warranty status"
+              },
+              {
+                "key": "service_history",
+                "label": "Service history"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "brand": "hyundai",
+      "label": "Hyundai",
+      "origin": "South Korea",
+      "popularInKsa": true,
+      "models": [
+        {
+          "model": "sonata",
+          "label": "Sonata",
+          "bodyType": "Sedan",
+          "year_min": 2015,
+          "year_max": 2024,
+          "trims": [
+            {
+              "trim": "smart",
+              "label": "Smart",
+              "engine": "2.5L I4",
+              "drivetrain": "FWD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2024
+              ]
+            },
+            {
+              "trim": "hybrid",
+              "label": "Hybrid",
+              "engine": "2.0L Hybrid",
+              "drivetrain": "FWD",
+              "transmission": "Automatic",
+              "fuel": "Hybrid",
+              "years": [
+                2023
+              ]
+            }
+          ],
+          "condition": {
+            "options": [
+              "new",
+              "used"
+            ],
+            "usedOnlyAttributes": [
+              {
+                "key": "mileage_km",
+                "label": "Mileage (km)"
+              },
+              {
+                "key": "owners_count",
+                "label": "Number of owners"
+              },
+              {
+                "key": "accident_history",
+                "label": "Accident history"
+              },
+              {
+                "key": "warranty_status",
+                "label": "Warranty status"
+              },
+              {
+                "key": "service_history",
+                "label": "Service history"
+              }
+            ]
+          }
+        },
+        {
+          "model": "tucson",
+          "label": "Tucson",
+          "bodyType": "SUV",
+          "year_min": 2015,
+          "year_max": 2024,
+          "trims": [
+            {
+              "trim": "gls",
+              "label": "GLS",
+              "engine": "2.5L I4",
+              "drivetrain": "AWD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2024
+              ]
+            }
+          ],
+          "condition": {
+            "options": [
+              "new",
+              "used"
+            ],
+            "usedOnlyAttributes": [
+              {
+                "key": "mileage_km",
+                "label": "Mileage (km)"
+              },
+              {
+                "key": "owners_count",
+                "label": "Number of owners"
+              },
+              {
+                "key": "accident_history",
+                "label": "Accident history"
+              },
+              {
+                "key": "warranty_status",
+                "label": "Warranty status"
+              },
+              {
+                "key": "service_history",
+                "label": "Service history"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "brand": "kia",
+      "label": "Kia",
+      "origin": "South Korea",
+      "popularInKsa": true,
+      "models": [
+        {
+          "model": "cerato",
+          "label": "Cerato",
+          "bodyType": "Sedan",
+          "year_min": 2016,
+          "year_max": 2024,
+          "trims": [
+            {
+              "trim": "ex",
+              "label": "EX",
+              "engine": "2.0L I4",
+              "drivetrain": "FWD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2024
+              ]
+            },
+            {
+              "trim": "gt-line",
+              "label": "GT Line",
+              "engine": "1.6L Turbo",
+              "drivetrain": "FWD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2023
+              ]
+            }
+          ],
+          "condition": {
+            "options": [
+              "new",
+              "used"
+            ],
+            "usedOnlyAttributes": [
+              {
+                "key": "mileage_km",
+                "label": "Mileage (km)"
+              },
+              {
+                "key": "owners_count",
+                "label": "Number of owners"
+              },
+              {
+                "key": "accident_history",
+                "label": "Accident history"
+              },
+              {
+                "key": "warranty_status",
+                "label": "Warranty status"
+              },
+              {
+                "key": "service_history",
+                "label": "Service history"
+              }
+            ]
+          }
+        },
+        {
+          "model": "sportage",
+          "label": "Sportage",
+          "bodyType": "SUV",
+          "year_min": 2016,
+          "year_max": 2024,
+          "trims": [
+            {
+              "trim": "gt",
+              "label": "GT",
+              "engine": "1.6L Turbo",
+              "drivetrain": "AWD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2024
+              ]
+            }
+          ],
+          "condition": {
+            "options": [
+              "new",
+              "used"
+            ],
+            "usedOnlyAttributes": [
+              {
+                "key": "mileage_km",
+                "label": "Mileage (km)"
+              },
+              {
+                "key": "owners_count",
+                "label": "Number of owners"
+              },
+              {
+                "key": "accident_history",
+                "label": "Accident history"
+              },
+              {
+                "key": "warranty_status",
+                "label": "Warranty status"
+              },
+              {
+                "key": "service_history",
+                "label": "Service history"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "brand": "ford",
+      "label": "Ford",
+      "origin": "USA",
+      "popularInKsa": true,
+      "models": [
+        {
+          "model": "expedition",
+          "label": "Expedition",
+          "bodyType": "SUV",
+          "year_min": 2015,
+          "year_max": 2024,
+          "trims": [
+            {
+              "trim": "limited",
+              "label": "Limited",
+              "engine": "3.5L EcoBoost",
+              "drivetrain": "4WD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2024
+              ]
+            }
+          ],
+          "condition": {
+            "options": [
+              "new",
+              "used"
+            ],
+            "usedOnlyAttributes": [
+              {
+                "key": "mileage_km",
+                "label": "Mileage (km)"
+              },
+              {
+                "key": "owners_count",
+                "label": "Number of owners"
+              },
+              {
+                "key": "accident_history",
+                "label": "Accident history"
+              },
+              {
+                "key": "warranty_status",
+                "label": "Warranty status"
+              },
+              {
+                "key": "service_history",
+                "label": "Service history"
+              }
+            ]
+          }
+        },
+        {
+          "model": "f-150",
+          "label": "F-150",
+          "bodyType": "Pickup",
+          "year_min": 2015,
+          "year_max": 2024,
+          "trims": [
+            {
+              "trim": "lariet",
+              "label": "Lariat",
+              "engine": "3.5L EcoBoost",
+              "drivetrain": "4WD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2024
+              ]
+            },
+            {
+              "trim": "platinum",
+              "label": "Platinum",
+              "engine": "5.0L V8",
+              "drivetrain": "4WD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2023
+              ]
+            }
+          ],
+          "condition": {
+            "options": [
+              "new",
+              "used"
+            ],
+            "usedOnlyAttributes": [
+              {
+                "key": "mileage_km",
+                "label": "Mileage (km)"
+              },
+              {
+                "key": "owners_count",
+                "label": "Number of owners"
+              },
+              {
+                "key": "accident_history",
+                "label": "Accident history"
+              },
+              {
+                "key": "warranty_status",
+                "label": "Warranty status"
+              },
+              {
+                "key": "service_history",
+                "label": "Service history"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "brand": "lexus",
+      "label": "Lexus",
+      "origin": "Japan",
+      "popularInKsa": true,
+      "models": [
+        {
+          "model": "es",
+          "label": "ES",
+          "bodyType": "Sedan",
+          "year_min": 2016,
+          "year_max": 2024,
+          "trims": [
+            {
+              "trim": "350-premier",
+              "label": "350 Premier",
+              "engine": "3.5L V6",
+              "drivetrain": "FWD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2024
+              ]
+            }
+          ],
+          "condition": {
+            "options": [
+              "new",
+              "used"
+            ],
+            "usedOnlyAttributes": [
+              {
+                "key": "mileage_km",
+                "label": "Mileage (km)"
+              },
+              {
+                "key": "owners_count",
+                "label": "Number of owners"
+              },
+              {
+                "key": "accident_history",
+                "label": "Accident history"
+              },
+              {
+                "key": "warranty_status",
+                "label": "Warranty status"
+              },
+              {
+                "key": "service_history",
+                "label": "Service history"
+              }
+            ]
+          }
+        },
+        {
+          "model": "lx",
+          "label": "LX",
+          "bodyType": "SUV",
+          "year_min": 2016,
+          "year_max": 2024,
+          "trims": [
+            {
+              "trim": "600-signature",
+              "label": "600 Signature",
+              "engine": "3.5L Twin-Turbo V6",
+              "drivetrain": "4WD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2024
+              ]
+            }
+          ],
+          "condition": {
+            "options": [
+              "new",
+              "used"
+            ],
+            "usedOnlyAttributes": [
+              {
+                "key": "mileage_km",
+                "label": "Mileage (km)"
+              },
+              {
+                "key": "owners_count",
+                "label": "Number of owners"
+              },
+              {
+                "key": "accident_history",
+                "label": "Accident history"
+              },
+              {
+                "key": "warranty_status",
+                "label": "Warranty status"
+              },
+              {
+                "key": "service_history",
+                "label": "Service history"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "brand": "bmw",
+      "label": "BMW",
+      "origin": "Germany",
+      "popularInKsa": true,
+      "models": [
+        {
+          "model": "series-5",
+          "label": "5 Series",
+          "bodyType": "Sedan",
+          "year_min": 2016,
+          "year_max": 2024,
+          "trims": [
+            {
+              "trim": "530i",
+              "label": "530i",
+              "engine": "2.0L Turbo",
+              "drivetrain": "RWD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2024
+              ]
+            }
+          ],
+          "condition": {
+            "options": [
+              "new",
+              "used"
+            ],
+            "usedOnlyAttributes": [
+              {
+                "key": "mileage_km",
+                "label": "Mileage (km)"
+              },
+              {
+                "key": "owners_count",
+                "label": "Number of owners"
+              },
+              {
+                "key": "accident_history",
+                "label": "Accident history"
+              },
+              {
+                "key": "warranty_status",
+                "label": "Warranty status"
+              },
+              {
+                "key": "service_history",
+                "label": "Service history"
+              }
+            ]
+          }
+        },
+        {
+          "model": "x5",
+          "label": "X5",
+          "bodyType": "SUV",
+          "year_min": 2016,
+          "year_max": 2024,
+          "trims": [
+            {
+              "trim": "xdrive40i",
+              "label": "xDrive40i",
+              "engine": "3.0L Turbo",
+              "drivetrain": "AWD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2024
+              ]
+            }
+          ],
+          "condition": {
+            "options": [
+              "new",
+              "used"
+            ],
+            "usedOnlyAttributes": [
+              {
+                "key": "mileage_km",
+                "label": "Mileage (km)"
+              },
+              {
+                "key": "owners_count",
+                "label": "Number of owners"
+              },
+              {
+                "key": "accident_history",
+                "label": "Accident history"
+              },
+              {
+                "key": "warranty_status",
+                "label": "Warranty status"
+              },
+              {
+                "key": "service_history",
+                "label": "Service history"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "brand": "mercedes-benz",
+      "label": "Mercedes-Benz",
+      "origin": "Germany",
+      "popularInKsa": true,
+      "models": [
+        {
+          "model": "e-class",
+          "label": "E-Class",
+          "bodyType": "Sedan",
+          "year_min": 2016,
+          "year_max": 2024,
+          "trims": [
+            {
+              "trim": "e200",
+              "label": "E 200",
+              "engine": "2.0L Turbo",
+              "drivetrain": "RWD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2024
+              ]
+            }
+          ],
+          "condition": {
+            "options": [
+              "new",
+              "used"
+            ],
+            "usedOnlyAttributes": [
+              {
+                "key": "mileage_km",
+                "label": "Mileage (km)"
+              },
+              {
+                "key": "owners_count",
+                "label": "Number of owners"
+              },
+              {
+                "key": "accident_history",
+                "label": "Accident history"
+              },
+              {
+                "key": "warranty_status",
+                "label": "Warranty status"
+              },
+              {
+                "key": "service_history",
+                "label": "Service history"
+              }
+            ]
+          }
+        },
+        {
+          "model": "gle",
+          "label": "GLE",
+          "bodyType": "SUV",
+          "year_min": 2016,
+          "year_max": 2024,
+          "trims": [
+            {
+              "trim": "gle450",
+              "label": "GLE 450",
+              "engine": "3.0L Turbo",
+              "drivetrain": "AWD",
+              "transmission": "Automatic",
+              "fuel": "Petrol",
+              "years": [
+                2024
+              ]
+            }
+          ],
+          "condition": {
+            "options": [
+              "new",
+              "used"
+            ],
+            "usedOnlyAttributes": [
+              {
+                "key": "mileage_km",
+                "label": "Mileage (km)"
+              },
+              {
+                "key": "owners_count",
+                "label": "Number of owners"
+              },
+              {
+                "key": "accident_history",
+                "label": "Accident history"
+              },
+              {
+                "key": "warranty_status",
+                "label": "Warranty status"
+              },
+              {
+                "key": "service_history",
+                "label": "Service history"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -1,0 +1,54 @@
+# Mazad.com MVP Overview
+
+## Vision
+Mazad.com is a Saudi marketplace that brings transparency and trust to auctions across vehicles, real estate, luxury goods, electronics, and services. The MVP focuses on high-intent categories with localized taxonomies, bilingual readiness, and data structures that downstream teams can extend without refactoring.
+
+## Strategic Objectives
+- **Trust first:** Provide certified listings, verified sellers, and clear inspection signals for vehicles.
+- **Liquidity:** Seed supply in core categories and streamline onboarding for professional sellers.
+- **Localization:** Reflect Saudi regulatory requirements, vehicle preferences, and Arabic terminology.
+- **Scalable foundation:** Deliver reusable schemas, IA, and UI scaffolding that accelerates later phases (ratings, monetization, AI features).
+
+## Scope Snapshot
+- **Audience:** Saudi buyers & sellers of vehicles and high-value goods.
+- **Platforms:** Responsive web (Next.js). Mobile apps are out of scope for MVP.
+- **Phases:** Three release waves (MVP1–MVP3) aligning with trust, growth, and monetization goals.
+
+## Success Metrics
+| Objective | Metric | Target |
+|-----------|--------|--------|
+| Supply activation | Active seller listings in Vehicles (first 90 days) | ≥ 2,000 |
+| Buyer engagement | Average session duration on listings | ≥ 4 minutes |
+| Trust | % of vehicle listings with inspection/condition data | ≥ 85% |
+| Conversion | Bid-to-listing ratio in Vehicles | ≥ 35% |
+
+## Stakeholders
+- **Product:** Aligns backlog with phased roadmap and user stories.
+- **Engineering:** Consumes data schemas, Next.js scaffold, and validation scripts.
+- **Design:** References IA, menu spec, and wireframe annotations.
+- **Operations:** Uses taxonomy and filters to curate listings, inspections, and certifications.
+
+## Assumptions & Dependencies
+- Classified data ingestion comes from partner feeds or manual seller entry.
+- Payment gateway and escrow workflows will be defined after MVP1.
+- Arabic localization content will be populated during Phase 2 using keys seeded in `data/i18n`.
+- Government regulations for auctions and vehicle transfers remain stable during MVP timeline.
+
+## Risks & Mitigation
+| Risk | Mitigation |
+|------|------------|
+| Fragmented vehicle data from sellers | Normalize inputs using brand/model/year pickers and enforce mandatory fields. |
+| Low buyer trust | Launch “Mazad Certified” flow in MVP2 and highlight inspection badges in UI specs. |
+| Complexity in filters | Use centralized `filters.json` schema with visible conditions for used vehicles. |
+| Scope creep | Track features against roadmap and acceptance criteria documents. |
+
+## Deliverable Map
+| Artifact | Location | Owner |
+|----------|----------|-------|
+| Category Tree | `docs/10-category-tree.md`, `data/categories.json` | Product Ops |
+| Vehicles Taxonomy | `docs/20-vehicles-taxonomy.md`, `data/vehicles/*.csv`, `data/vehicles/vehicles.json` | Data Services |
+| User Stories & ACs | `docs/30-32-*.md` | Product Management |
+| IA & UI Spec | `docs/40-ia-menu-spec.md` | Product Design |
+| Roadmap | `docs/50-roadmap-mvp1-3.md` | Product Leadership |
+| App Scaffold | `/app` | Engineering |
+| Validation Scripts | `/scripts/validate-json.mjs` | Engineering Enablement |

--- a/docs/10-category-tree.md
+++ b/docs/10-category-tree.md
@@ -1,0 +1,106 @@
+# Category Tree & Navigation Model
+
+Mazad.com launches with nine super-categories tailored for the Saudi market. Each entry includes its machine slug, description, and top-level subcategories.
+
+## Super-Categories
+| Label | Slug | Description |
+|-------|------|-------------|
+| Vehicles | vehicles | Cars, motorcycles, commercial transport, and parts optimized for Saudi regulations. |
+| Real Estate | real-estate | Residential, commercial, and land listings compliant with Saudi property norms. |
+| Luxury | luxury | Watches, jewelry, collectibles, and premium accessories. |
+| Electronics | electronics | Consumer electronics, mobiles, computers, and accessories. |
+| Home & Living | home-and-living | Furniture, appliances, and décor. |
+| Fashion | fashion | Apparel, footwear, and accessories for men, women, and children. |
+| Sports & Outdoors | sports-and-outdoors | Sporting goods, fitness equipment, and outdoor gear. |
+| Business & Industrial | business-and-industrial | Machinery, tools, and B2B supplies. |
+| Services | services | Professional and household services across Saudi cities. |
+
+## Vehicles Subcategories
+- **Cars** (`cars`): Sedan, SUV, Coupe, Hatchback, Pickup.
+- **Motorcycles** (`motorcycles`): Street, Cruiser, Off-road, Scooters.
+- **Commercial Vehicles** (`commercial-vehicles`): Vans, Trucks, Buses.
+- **Parts & Accessories** (`parts-accessories`): Engines, Body parts, Tires, Electronics.
+- **Marine** (`marine`): Boats, Jet Skis, Trailers.
+
+### Filter Highlights
+- Aligns with `data/filters.json` keys such as `brand`, `model`, `year`, `condition`, `mileage`, and `warranty`.
+- Used-only filters (mileage, owners, accident history) are conditionally visible when `condition = used`.
+
+## Real Estate Subcategories
+- **Residential Sales** (`residential-sales`): Villas, Apartments, Townhouses.
+- **Residential Rentals** (`residential-rentals`): Long-term, Short-term, Serviced apartments.
+- **Commercial** (`commercial`): Offices, Retail, Warehouses.
+- **Land & Plots** (`land-plots`): Urban, Suburban, Agricultural.
+- **Co-living & Shared** (`coliving-shared`): Shared apartments, Rooms for rent.
+
+### Filter Highlights
+- `property_type`, `location_city`, `price_range`, `bedrooms`, `furnished`, `area_sqm`.
+- Compliance fields: `deed_verified`, `available_from`.
+
+## Luxury Subcategories
+- **Watches** (`watches`)
+- **Jewelry** (`jewelry`)
+- **Designer Bags** (`designer-bags`)
+- **Collectibles** (`collectibles`)
+- **Luxury Autos** (`luxury-autos`)
+
+Filters emphasize authenticity: `brand`, `condition`, `authenticity_docs`, `year_of_purchase`.
+
+## Electronics Subcategories
+- **Mobile Phones** (`mobile-phones`)
+- **Laptops & Computers** (`laptops-computers`)
+- **Home Entertainment** (`home-entertainment`)
+- **Smart Home** (`smart-home`)
+- **Gaming** (`gaming`)
+
+Filters: `brand`, `model`, `storage_size`, `warranty_remaining`, `condition`.
+
+## Home & Living Subcategories
+- **Furniture** (`furniture`)
+- **Appliances** (`appliances`)
+- **Kitchen & Dining** (`kitchen-dining`)
+- **Home Décor** (`home-decor`)
+- **Outdoor & Garden** (`outdoor-garden`)
+
+Filters: `brand`, `material`, `color`, `condition`, `dimension_notes`.
+
+## Fashion Subcategories
+- **Men** (`men`)
+- **Women** (`women`)
+- **Kids** (`kids`)
+- **Luxury Fashion** (`luxury-fashion`)
+- **Traditional Wear** (`traditional-wear`)
+
+Filters: `brand`, `size`, `condition`, `authenticity_docs`, `season`.
+
+## Sports & Outdoors Subcategories
+- **Fitness Equipment** (`fitness-equipment`)
+- **Team Sports** (`team-sports`)
+- **Outdoor Adventure** (`outdoor-adventure`)
+- **Cycling** (`cycling`)
+- **Water Sports** (`water-sports`)
+
+Filters: `brand`, `equipment_type`, `condition`, `usage_level`.
+
+## Business & Industrial Subcategories
+- **Heavy Machinery** (`heavy-machinery`)
+- **Tools & Hardware** (`tools-hardware`)
+- **Office Equipment** (`office-equipment`)
+- **Industrial Supplies** (`industrial-supplies`)
+- **Wholesale Lots** (`wholesale-lots`)
+
+Filters: `brand`, `condition`, `power_requirement`, `usage_hours`, `location_city`.
+
+## Services Subcategories
+- **Automotive Services** (`automotive-services`)
+- **Home Services** (`home-services`)
+- **Professional Services** (`professional-services`)
+- **Events & Catering** (`events-catering`)
+- **Logistics & Delivery** (`logistics-delivery`)
+
+Filters: `service_type`, `coverage_city`, `availability`, `pricing_model`, `certifications`.
+
+## Navigation Notes
+- Global navigation features category mega-menu with hover reveal of subcategories.
+- `/categories` route lists all super-categories with icons and call-to-action.
+- Each leaf node surfaces recommended filters and quick links to featured searches.

--- a/docs/20-vehicles-taxonomy.md
+++ b/docs/20-vehicles-taxonomy.md
@@ -1,0 +1,78 @@
+# Vehicles Taxonomy Reference
+
+This document describes the canonical vehicles taxonomy for Mazad.com. Data is stored in CSV and JSON under `data/vehicles/` and validated via `schemas/vehicles.schema.json`.
+
+## Data Sources
+- **`brands.csv`** – Brand slug, label, country of origin, popular-in-KSA flag.
+- **`models.csv`** – Model slug, associated brand, body type, production years.
+- **`trims.csv`** – Trim-level metadata per model and year (engine, drivetrain, transmission).
+- **`vehicles.json`** – Generated aggregate view consumed by the Next.js app and filters.
+
+## Hierarchy & Keys
+| Level | Identifier | Example |
+|-------|------------|---------|
+| Brand | `brand_slug` | `toyota` |
+| Model | `model_slug` | `land-cruiser` |
+| Year Range | `year_min` / `year_max` | `2016`–`2024` |
+| Trim | `trim_slug` | `gxr-v6` |
+
+## Condition Attributes
+All vehicle entries specify `conditionOptions: ["new", "used"]`. When `used` is selected, additional attributes become visible in filters and listing forms:
+- `mileage_km`
+- `owners_count`
+- `accident_history`
+- `warranty_status`
+- `service_history`
+
+## Brand Coverage (Top 8 for MVP1)
+| Brand | Origin | Notes |
+|-------|--------|-------|
+| Toyota | Japan | Highest market share in KSA; prioritize Land Cruiser, Camry, Corolla. |
+| Nissan | Japan | Focus on Patrol and X-Trail for desert performance. |
+| Hyundai | South Korea | Popular sedans and SUVs (Sonata, Tucson). |
+| Kia | South Korea | Sportage, Sorento, and Cerato demand. |
+| Ford | USA | F-150 and Expedition for government/fleet use. |
+| Lexus | Japan | Premium SUVs and sedans (LX, ES). |
+| BMW | Germany | Luxury sedans/SUVs (5 Series, X5). |
+| Mercedes-Benz | Germany | Luxury sedans/SUVs (E-Class, GLE). |
+
+## Example Vehicle Object
+```json
+{
+  "brand": "toyota",
+  "label": "Toyota",
+  "origin": "Japan",
+  "models": [
+    {
+      "model": "land-cruiser",
+      "label": "Land Cruiser",
+      "body_type": "SUV",
+      "year_min": 2016,
+      "year_max": 2024,
+      "trims": [
+        { "trim": "gxr-v6", "label": "GXR V6", "engine": "4.0L", "drivetrain": "4WD" },
+        { "trim": "vxr-v8", "label": "VXR V8", "engine": "5.7L", "drivetrain": "4WD" }
+      ],
+      "condition": {
+        "options": ["new", "used"],
+        "usedOnlyAttributes": ["mileage_km", "owners_count", "accident_history", "warranty_status", "service_history"]
+      }
+    }
+  ]
+}
+```
+
+## Data Maintenance Workflow
+1. Product Ops updates `brands.csv`, `models.csv`, or `trims.csv` when new inventory arrives.
+2. Run `npm run generate:vehicles` to rebuild `data/vehicles/vehicles.json`.
+3. Commit CSV and JSON changes together to keep parity between tabular and hierarchical views.
+4. Execute `npm run validate` to ensure JSON meets schema requirements.
+
+## Localization Strategy
+- Display labels default to English; Arabic translations stored in `data/i18n/ar.json` (Phase 2).
+- Keys remain stable across locales (`brand`, `model`, `trim`).
+
+## Future Extensions
+- VIN decoding integration for Phase 3 advanced filters.
+- Integration hooks for inspection providers to append condition reports.
+- Electric vehicle-specific fields (battery health, charging standard).

--- a/docs/30-user-stories-buyer.md
+++ b/docs/30-user-stories-buyer.md
@@ -1,0 +1,70 @@
+# Buyer User Stories (Phase Labels & Acceptance Criteria)
+
+## EPIC: Discover & Browse Inventory (MVP1)
+
+### Story B1: Browse categories
+**As a** buyer, **I want** to browse all marketplace categories, **so that** I can quickly navigate to items of interest.
+- **Phase:** MVP1
+- **Acceptance Criteria:**
+  1. Categories page lists all nine super-categories with localized labels.
+  2. Selecting a category routes to `/categories/[slug]` showing subcategories and featured filters.
+  3. Breadcrumbs update to reflect the category path.
+  4. Analytics event `category_view` fires with `{ categorySlug }`.
+
+### Story B2: Filter vehicle listings
+**As a** buyer, **I want** to filter vehicles by brand, model, year, and condition, **so that** I can narrow options quickly.
+- **Phase:** MVP1
+- **Acceptance Criteria:**
+  1. Filter panel displays available filters defined for `vehicles` in `data/filters.json`.
+  2. Selecting `condition = used` reveals used-only filters (mileage, owners, accident history).
+  3. Filter selections update query params without full page reload.
+  4. Listing results refresh with applied filters and show count of matches.
+
+### Story B3: View listing details
+**As a** buyer, **I want** to view a detailed listing page with inspection data, **so that** I can evaluate trustworthiness.
+- **Phase:** MVP1
+- **Acceptance Criteria:**
+  1. Listing page shows seller info, vehicle specs, photos, and inspection summary.
+  2. Condition badges (New/Used) appear with iconography described in IA spec.
+  3. If `Mazad Certified` flag is present, display certification card with inspection date.
+  4. Related listings section surfaces 4 items matching brand/model.
+
+## EPIC: Transact with Confidence (MVP2)
+
+### Story B4: Follow a listing
+**As a** buyer, **I want** to follow listings and receive notifications, **so that** I never miss bid updates.
+- **Phase:** MVP2
+- **Acceptance Criteria:**
+  1. Clicking “Follow” subscribes buyer to listing events and updates CTA to “Following”.
+  2. Buyer receives notification preferences modal (email, SMS, push placeholder).
+  3. Event payload conforms to notifications schema (`eventType`, `listingId`, `userId`).
+  4. Buyers can unfollow from listing or notifications center.
+
+### Story B5: Review Mazad Certified inspection
+**As a** buyer, **I want** to review inspection reports for certified listings, **so that** I can trust vehicle condition.
+- **Phase:** MVP2
+- **Acceptance Criteria:**
+  1. Certified badge links to modal with inspection checklist (exterior, interior, mechanical, documentation).
+  2. Modal includes inspector name, certification date, and downloadable PDF placeholder.
+  3. Buyers can flag discrepancies, creating support ticket with listing context.
+  4. Analytics event `inspection_view` captured with `certified: true`.
+
+## EPIC: Optimize Purchase Decision (MVP3)
+
+### Story B6: Receive AI price estimate
+**As a** buyer, **I want** to see AI-generated price guidance, **so that** I know if the current bid is fair.
+- **Phase:** MVP3
+- **Acceptance Criteria:**
+  1. Price estimator consumes brand, model, year, trim, mileage to return `estimate_low`, `estimate_high`.
+  2. Estimate panel displays confidence score and disclaimer text.
+  3. If AI service fails, fallback message explains manual valuation process.
+  4. Event `ai_price_estimate` records estimation inputs and response time.
+
+### Story B7: Compare multiple listings
+**As a** buyer, **I want** to compare up to three listings side-by-side, **so that** I can select the best value.
+- **Phase:** MVP3
+- **Acceptance Criteria:**
+  1. Compare widget accepts maximum of three listings and displays key attributes (price, mileage, warranty).
+  2. Listings can be added from search results or detail page.
+  3. Comparison state persists across session via local storage.
+  4. Buyers can remove items individually or clear all.

--- a/docs/31-user-stories-seller.md
+++ b/docs/31-user-stories-seller.md
@@ -1,0 +1,70 @@
+# Seller User Stories (Phase Labels & Acceptance Criteria)
+
+## EPIC: Onboard & List Inventory (MVP1)
+
+### Story S1: Register as seller
+**As a** seller, **I want** to register my business profile, **so that** I can list inventory under Mazad.com policies.
+- **Phase:** MVP1
+- **Acceptance Criteria:**
+  1. Registration form captures business name, CR number, city, and contact info.
+  2. Sellers upload trade license copy or enter manual verification code.
+  3. Successful submission triggers verification workflow and sends confirmation email.
+  4. Seller dashboard status displays `Pending Verification` until approved.
+
+### Story S2: Create vehicle listing
+**As a** seller, **I want** to list a vehicle with accurate specs, **so that** buyers can trust my inventory.
+- **Phase:** MVP1
+- **Acceptance Criteria:**
+  1. Listing form consumes taxonomy from `vehicles.json` enabling brand→model→year→trim selection.
+  2. Mandatory fields: mileage (if used), condition, price expectations, inspection availability.
+  3. Upload at least 6 photos and 1 inspection document placeholder.
+  4. Submission triggers moderation queue entry with SLA timestamp.
+
+### Story S3: Manage listings
+**As a** seller, **I want** to edit or pause listings, **so that** I maintain accurate availability.
+- **Phase:** MVP1
+- **Acceptance Criteria:**
+  1. Sellers can toggle listing status between `Active`, `Paused`, `Sold`.
+  2. Edited listings retain audit trail of changes.
+  3. Notifications sent to followers when listing is paused or sold.
+  4. Updates respect moderation rules (critical changes re-queued for review).
+
+## EPIC: Build Trust & Performance (MVP2)
+
+### Story S4: Apply for Mazad Certified
+**As a** seller, **I want** to submit vehicles for certification, **so that** I can boost buyer confidence.
+- **Phase:** MVP2
+- **Acceptance Criteria:**
+  1. Sellers request certification from listing detail with preferred inspection partner.
+  2. Workflow collects fees and schedules inspection time slot.
+  3. Certification results update listing with badge, expiry date, and checklist summary.
+  4. Certification status visible in seller dashboard analytics.
+
+### Story S5: Respond to buyer inquiries
+**As a** seller, **I want** to respond to buyer messages quickly, **so that** I maintain lead quality.
+- **Phase:** MVP2
+- **Acceptance Criteria:**
+  1. Messaging center groups conversations by listing and shows unread count.
+  2. Response time SLA tracked and surfaced as a trust metric on listings.
+  3. Buyers receive notification when seller replies.
+  4. Agents can mark conversation as resolved.
+
+## EPIC: Optimize Revenue (MVP3)
+
+### Story S6: Promote featured listing
+**As a** seller, **I want** to boost a listing for higher visibility, **so that** I can reach more buyers.
+- **Phase:** MVP3
+- **Acceptance Criteria:**
+  1. Sellers choose from Featured or Boost packages defined in pricing matrix.
+  2. Payment status tracked and invoice generated.
+  3. Featured listings appear in carousel slots per IA spec.
+  4. Performance analytics show impressions, clicks, and conversion per boost.
+
+### Story S7: Access performance analytics
+**As a** seller, **I want** to track listing performance metrics, **so that** I can optimize my inventory strategy.
+- **Phase:** MVP3
+- **Acceptance Criteria:**
+  1. Dashboard charts show bids, watchlist adds, conversions by time period.
+  2. Sellers can export CSV of metrics for selected date range.
+  3. Filters allow segmentation by category and certification status.
+  4. Data refreshes daily with timestamp indicator.

--- a/docs/32-acceptance-criteria.md
+++ b/docs/32-acceptance-criteria.md
@@ -1,0 +1,34 @@
+# Global Acceptance Criteria Matrix
+
+This matrix ties the MVP scope to verifiable outcomes across documentation, data, and application layers.
+
+## Data & Taxonomy (AC-01 to AC-04)
+| ID | Description | Verification |
+|----|-------------|--------------|
+| AC-01 | `data/categories.json` lists all nine super-categories with stable slugs and nested subcategories. | Run `npm run validate` → categories schema passes. |
+| AC-02 | `data/filters.json` defines filter configurations per category (type, options, dependencies). | Run `npm run validate` → filters schema passes. |
+| AC-03 | Vehicles JSON includes brand, model, `year_min`, `year_max`, `trims[]`, `condition.options`, and used-only attributes. | Run `npm run validate` → vehicles schema passes. |
+| AC-04 | JSON validates against schemas in `/schemas` via `scripts/validate-json.mjs`. | Command exit code 0 with summary log. |
+
+## Documentation & Planning (AC-05 to AC-08)
+| ID | Description | Verification |
+|----|-------------|--------------|
+| AC-05 | User stories cover buyer and seller personas with MVP1–3 labels. | Review `docs/30-user-stories-buyer.md` and `docs/31-user-stories-seller.md`. |
+| AC-06 | Roadmap outlines MVP1–3 with milestones, KPIs, and dependencies. | Review `docs/50-roadmap-mvp1-3.md`. |
+| AC-07 | IA spec includes Mermaid diagram and wireframe annotations for listing flow. | Review `docs/40-ia-menu-spec.md`. |
+| AC-08 | Vehicles taxonomy documentation details CSV/JSON workflow. | Review `docs/20-vehicles-taxonomy.md`. |
+
+## Application Scaffold (AC-09 to AC-12)
+| ID | Description | Verification |
+|----|-------------|--------------|
+| AC-09 | Next.js app builds with TypeScript and renders category menu from `data/categories.json`. | Run `npm run build` or `npm run dev` locally; screenshot optional. |
+| AC-10 | `/categories/[slug]` page shows subcategories and filter chips. | Manual QA via dev server. |
+| AC-11 | `/categories/cars/[brand]/[model]` renders vehicle model overview with trims list. | Manual QA via dev server with seeded data. |
+| AC-12 | Filter panel component shows conditional fields based on `visibleWhen`. | Manual QA verifying toggled state. |
+
+## Operational Excellence (AC-13 to AC-15)
+| ID | Description | Verification |
+|----|-------------|--------------|
+| AC-13 | Scripts exist for JSON validation and vehicles JSON generation. | Inspect `scripts/validate-json.mjs`, `scripts/generate-vehicles-json.mjs`. |
+| AC-14 | README and docs provide onboarding guidance for engineers. | Review `README.md` updates. |
+| AC-15 | Localization keys seeded for English & Arabic placeholders. | Check `data/i18n/en.json`, `data/i18n/ar.json`. |

--- a/docs/40-ia-menu-spec.md
+++ b/docs/40-ia-menu-spec.md
@@ -1,0 +1,72 @@
+# Information Architecture & Menu Spec
+
+## Global Navigation
+- Top nav includes logo, mega menu trigger, search bar, language toggle (EN/AR), and user menu.
+- Mega menu surfaces all nine super-categories with supporting imagery.
+- Hovering a super-category reveals secondary panel with subcategories and quick filters.
+
+## Category Navigation Flow
+```mermaid
+flowchart TD
+  A[Home] --> B[Categories]
+  B --> C[Vehicles]
+  C --> C1[Cars]
+  C1 --> C1a[Brand]
+  C1a --> C1b[Model]
+  C1b --> C1c[Year]
+  C1c --> C1d[Trim]
+  C1d --> C1e[Condition]
+  B --> D[Real Estate]
+  B --> E[Electronics]
+  B --> F[Home & Living]
+  B --> G[Luxury]
+  B --> H[Fashion]
+  B --> I[Sports]
+  B --> J[Business & Industrial]
+  B --> K[Services]
+```
+
+## Page Templates
+### Categories Index (`/categories`)
+- Grid layout with cards per super-category.
+- Card contents: icon, label, description, CTA button (“Browse Vehicles”).
+- Secondary column highlights featured stories (e.g., “Mazad Certified explained”).
+
+### Category Detail (`/categories/[slug]`)
+- Hero banner with category imagery and description.
+- Subcategory list with counts (powered by supply metrics).
+- Filter chips for top queries (e.g., `SUVs under SAR 200K`).
+- SEO block with FAQ accordion.
+
+### Vehicles Brand Model (`/categories/cars/[brand]/[model]`)
+- Header showing brand + model + production years.
+- Trim cards list engine, drivetrain, transmission, price guidance.
+- Sticky filter panel on desktop referencing `FilterPanel` component.
+- Related content: certification info, financing CTA placeholder.
+
+## Component Contracts
+### `CategoryMenu`
+- Props: `{ categories: Category[] }`
+- Behavior: renders mega menu tree, handles slug-based routing.
+- Responsive: collapses to accordion on mobile.
+
+### `FilterPanel`
+- Props: `{ filters: CategoryFilter[], state: Record<string, unknown> }`
+- Renders segmented control, select dropdowns, and range sliders based on filter type.
+- Applies conditional visibility using `visibleWhen` property.
+
+### `ListingCard`
+- Props: `{ listing: ListingSummary }`
+- Displays image, title, key specs (price, mileage, location), badges (Certified, New/Used).
+- On click navigate to detail page using Next.js `<Link>`.
+
+## Wireframe Notes
+- Desktop width: 1440px grid with 12 columns; mobile: 375px.
+- Hero sections use 60/40 text-to-image split with CTA for seller onboarding.
+- Listing grid uses 3 columns on desktop, 2 on tablet, 1 on mobile.
+- Sticky bid widget on detail page shows countdown timer and call-to-action.
+
+## Accessibility & Localization
+- All nav items accessible via keyboard with visible focus states.
+- Language toggle updates `dir` attribute for Arabic in future release.
+- Icons accompanied by text labels to maintain clarity for screen readers.

--- a/docs/50-roadmap-mvp1-3.md
+++ b/docs/50-roadmap-mvp1-3.md
@@ -1,0 +1,48 @@
+# Roadmap MVP1–MVP3
+
+## Phase Overview
+| Phase | Goal | Timeframe | Primary KPIs |
+|-------|------|-----------|--------------|
+| MVP1 – Core Foundation | Launch vehicle-first marketplace with trusted taxonomy and browsing. | Months 0–3 | Listings supply, buyer engagement time. |
+| MVP2 – Trust & Growth | Introduce certification, notifications, and dashboards to drive retention. | Months 4–6 | Certification adoption, follow actions, seller response SLAs. |
+| MVP3 – Monetization & Scale | Unlock boosts, seller plans, and AI enhancements for revenue growth. | Months 7–9 | Boost revenue, AI feature usage, seller retention. |
+
+## MVP1 Backlog Highlights
+- Publish taxonomy (`categories.json`, `vehicles.json`) and filters.
+- Ship buyer/seller onboarding flows with moderation guardrails.
+- Release initial Next.js experience: category browse, listing detail, placeholder bidding widget.
+- Enable CSV→JSON data pipeline and validation scripts.
+- Deliver analytics instrumentation plan for key events (view, filter, follow).
+
+### Dependencies
+- Seller verification service integration.
+- CDN for image hosting and optimization.
+- Localization strings defined for EN with placeholders for AR.
+
+## MVP2 Backlog Highlights
+- Launch Mazad Certified workflow: inspection scheduling, badge display, certification policy doc.
+- Build notifications service (outbid, ending soon, inspection ready) with schema definitions.
+- Implement buyer/seller dashboards with performance metrics and messaging inbox.
+- Release ratings & reviews data model and UI entry points.
+
+### Dependencies
+- Partner inspection providers in Riyadh, Jeddah, Dammam.
+- Notification delivery channels (email, SMS provider).
+- Legal review of certification and inspection policy.
+
+## MVP3 Backlog Highlights
+- Introduce featured listings & boost pricing matrix with configurable packages.
+- Offer subscription-based seller plans (tiers with limits, analytics).
+- Integrate AI price estimator and VIN lookup for advanced buyers.
+- Expand filters for EV-specific attributes and financing offers.
+
+### Dependencies
+- Pricing & billing integration (Stripe-like provider or in-house invoicing).
+- Data science services for AI estimation.
+- Regulatory compliance for VIN services.
+
+## Release Management
+- Operate two-week sprints with formal phase gates at the end of each MVP milestone.
+- Conduct usability testing before MVP1 launch and before major MVP2/MVP3 features.
+- Maintain single source of truth backlog in Jira; map doc references to ticket IDs.
+- Phase retro documents stored alongside roadmap for institutional knowledge.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "mazad-mvp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "validate": "node scripts/validate-json.mjs",
+    "generate:vehicles": "node scripts/generate-vehicles-json.mjs"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.30",
+    "@types/react": "18.2.47",
+    "@types/react-dom": "18.2.18",
+    "autoprefixer": "10.4.16",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "postcss": "8.4.38",
+    "tailwindcss": "3.4.3",
+    "typescript": "5.4.5"
+  }
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/schemas/categories.schema.json
+++ b/schemas/categories.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Mazad Categories",
+  "type": "object",
+  "required": ["version", "categories"],
+  "additionalProperties": false,
+  "properties": {
+    "version": { "type": "string" },
+    "categories": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/category" }
+    }
+  },
+  "definitions": {
+    "category": {
+      "type": "object",
+      "required": ["slug", "label"],
+      "additionalProperties": false,
+      "properties": {
+        "slug": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+        "label": { "type": "string" },
+        "description": { "type": "string" },
+        "icon": { "type": "string" },
+        "featuredFilters": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "children": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/category" }
+        }
+      }
+    }
+  }
+}

--- a/schemas/filters.schema.json
+++ b/schemas/filters.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Mazad Filters",
+  "type": "object",
+  "required": ["version", "filters"],
+  "additionalProperties": false,
+  "properties": {
+    "version": { "type": "string" },
+    "filters": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "array",
+        "items": { "$ref": "#/definitions/filter" }
+      }
+    }
+  },
+  "definitions": {
+    "filter": {
+      "type": "object",
+      "required": ["key", "type"],
+      "additionalProperties": false,
+      "properties": {
+        "key": { "type": "string", "pattern": "^[a-z0-9_-]+$" },
+        "type": {
+          "type": "string",
+          "enum": ["select", "range", "segmented", "number", "date", "text"]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              { "type": "string" },
+              {
+                "type": "object",
+                "required": ["value", "label"],
+                "properties": {
+                  "value": { "type": "string" },
+                  "label": { "type": "string" }
+                },
+                "additionalProperties": false
+              }
+            ]
+          }
+        },
+        "source": { "type": "string" },
+        "dependsOn": { "type": "string" },
+        "min": { "type": "number" },
+        "max": { "type": "number" },
+        "unit": { "type": "string" },
+        "default": { "type": ["string", "number"] },
+        "visibleWhen": {
+          "type": "object",
+          "additionalProperties": { "type": ["string", "number", "boolean"] }
+        }
+      }
+    }
+  }
+}

--- a/schemas/vehicles.schema.json
+++ b/schemas/vehicles.schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Mazad Vehicles",
+  "type": "object",
+  "required": ["version", "brands"],
+  "additionalProperties": false,
+  "properties": {
+    "version": { "type": "string" },
+    "generatedAt": { "type": "string" },
+    "brands": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/brand" }
+    }
+  },
+  "definitions": {
+    "brand": {
+      "type": "object",
+      "required": ["brand", "label", "origin", "popularInKsa", "models"],
+      "additionalProperties": false,
+      "properties": {
+        "brand": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+        "label": { "type": "string" },
+        "origin": { "type": "string" },
+        "popularInKsa": { "type": "boolean" },
+        "models": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/model" }
+        }
+      }
+    },
+    "model": {
+      "type": "object",
+      "required": ["model", "label", "bodyType", "year_min", "year_max", "trims", "condition"],
+      "additionalProperties": false,
+      "properties": {
+        "model": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+        "label": { "type": "string" },
+        "bodyType": { "type": "string" },
+        "year_min": { "type": "integer" },
+        "year_max": { "type": "integer" },
+        "trims": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/trim" }
+        },
+        "condition": { "$ref": "#/definitions/condition" }
+      }
+    },
+    "trim": {
+      "type": "object",
+      "required": ["trim", "label", "years"],
+      "additionalProperties": false,
+      "properties": {
+        "trim": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+        "label": { "type": "string" },
+        "engine": { "type": "string" },
+        "drivetrain": { "type": "string" },
+        "transmission": { "type": "string" },
+        "fuel": { "type": "string" },
+        "years": {
+          "type": "array",
+          "items": { "type": "integer" }
+        }
+      }
+    },
+    "condition": {
+      "type": "object",
+      "required": ["options", "usedOnlyAttributes"],
+      "additionalProperties": false,
+      "properties": {
+        "options": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "usedOnlyAttributes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["key", "label"],
+            "additionalProperties": false,
+            "properties": {
+              "key": { "type": "string" },
+              "label": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/generate-vehicles-json.mjs
+++ b/scripts/generate-vehicles-json.mjs
@@ -1,0 +1,128 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+const vehiclesDir = path.join(rootDir, 'data', 'vehicles');
+
+const usedAttributes = [
+  { key: 'mileage_km', label: 'Mileage (km)' },
+  { key: 'owners_count', label: 'Number of owners' },
+  { key: 'accident_history', label: 'Accident history' },
+  { key: 'warranty_status', label: 'Warranty status' },
+  { key: 'service_history', label: 'Service history' }
+];
+
+const parseCsv = async (filename) => {
+  const filePath = path.join(vehiclesDir, filename);
+  const contents = await readFile(filePath, 'utf8');
+  const lines = contents.trim().split(/\r?\n/);
+  const headers = lines.shift()?.split(',') ?? [];
+
+  return lines.map((line) => {
+    const cells = line.split(',');
+    return headers.reduce((accumulator, header, index) => {
+      accumulator[header] = cells[index]?.trim() ?? '';
+      return accumulator;
+    }, {});
+  });
+};
+
+const groupTrims = (trimRows) => {
+  const grouped = new Map();
+
+  for (const row of trimRows) {
+    const modelKey = `${row.brand}:${row.model}`;
+    let trimMap = grouped.get(modelKey);
+    if (!trimMap) {
+      trimMap = new Map();
+      grouped.set(modelKey, trimMap);
+    }
+
+    const trimKey = row.trim;
+    let trim = trimMap.get(trimKey);
+    if (!trim) {
+      trim = {
+        trim: row.trim,
+        label: row.trim_label,
+        engine: row.engine || undefined,
+        drivetrain: row.drivetrain || undefined,
+        transmission: row.transmission || undefined,
+        fuel: row.fuel || undefined,
+        years: []
+      };
+      trimMap.set(trimKey, trim);
+    }
+
+    const year = Number.parseInt(row.year, 10);
+    if (!Number.isNaN(year) && !trim.years.includes(year)) {
+      trim.years.push(year);
+      trim.years.sort((a, b) => a - b);
+    }
+  }
+
+  return grouped;
+};
+
+async function generate() {
+  const [brandRows, modelRows, trimRows] = await Promise.all([
+    parseCsv('brands.csv'),
+    parseCsv('models.csv'),
+    parseCsv('trims.csv')
+  ]);
+
+  const trimsByModel = groupTrims(trimRows);
+
+  const brands = brandRows.map((brandRow) => {
+    const models = modelRows
+      .filter((modelRow) => modelRow.brand === brandRow.brand)
+      .map((modelRow) => {
+        const trimsMap = trimsByModel.get(`${modelRow.brand}:${modelRow.model}`) ?? new Map();
+        const trims = Array.from(trimsMap.values());
+
+        if (trims.length === 0) {
+          throw new Error(`Model ${modelRow.brand}/${modelRow.model} is missing trims in trims.csv`);
+        }
+
+        return {
+          model: modelRow.model,
+          label: modelRow.label,
+          bodyType: modelRow.body_type,
+          year_min: Number.parseInt(modelRow.year_start, 10),
+          year_max: Number.parseInt(modelRow.year_end, 10),
+          trims,
+          condition: {
+            options: ['new', 'used'],
+            usedOnlyAttributes: usedAttributes
+          }
+        };
+      })
+      .sort((a, b) => a.label.localeCompare(b.label));
+
+    return {
+      brand: brandRow.brand,
+      label: brandRow.label,
+      origin: brandRow.origin,
+      popularInKsa: String(brandRow.popular_in_ksa).toLowerCase() === 'true',
+      models
+    };
+  });
+
+  const vehiclesJson = {
+    version: '2024-06-01',
+    generatedAt: new Date().toISOString(),
+    brands
+  };
+
+  const outputPath = path.join(vehiclesDir, 'vehicles.json');
+  await writeFile(outputPath, JSON.stringify(vehiclesJson, null, 2));
+  console.log(`✅ Generated vehicles.json with ${brands.length} brands.`);
+}
+
+generate().catch((error) => {
+  console.error('Failed to generate vehicles.json');
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/validate-json.mjs
+++ b/scripts/validate-json.mjs
@@ -1,0 +1,205 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+
+const readJson = async (relativePath) => {
+  const filePath = path.join(rootDir, relativePath);
+  const contents = await readFile(filePath, 'utf8');
+  return JSON.parse(contents);
+};
+
+const matchesType = (type, value) => {
+  switch (type) {
+    case 'string':
+      return typeof value === 'string';
+    case 'number':
+      return typeof value === 'number' && Number.isFinite(value);
+    case 'integer':
+      return typeof value === 'number' && Number.isInteger(value);
+    case 'boolean':
+      return typeof value === 'boolean';
+    case 'array':
+      return Array.isArray(value);
+    case 'object':
+      return typeof value === 'object' && value !== null && !Array.isArray(value);
+    default:
+      return true;
+  }
+};
+
+const resolveRef = (schema, ref) => {
+  if (!ref.startsWith('#/')) {
+    return undefined;
+  }
+  const pathSegments = ref
+    .replace(/^#\//, '')
+    .split('/')
+    .map((segment) => segment.replace(/~1/g, '/').replace(/~0/g, '~'));
+  let current = schema;
+  for (const segment of pathSegments) {
+    current = current?.[segment];
+    if (current === undefined) {
+      return undefined;
+    }
+  }
+  return current;
+};
+
+const validateSchema = (schema, data, rootSchema, pathSegments, errors) => {
+  if (!schema) {
+    return;
+  }
+
+  if (schema.$ref) {
+    const refSchema = resolveRef(rootSchema, schema.$ref);
+    if (!refSchema) {
+      errors.push({ path: pathSegments.join('.'), message: `Unknown $ref ${schema.$ref}` });
+      return;
+    }
+    validateSchema(refSchema, data, rootSchema, pathSegments, errors);
+    return;
+  }
+
+  if (schema.anyOf) {
+    const matches = schema.anyOf.some((option) => {
+      const optionErrors = [];
+      validateSchema(option, data, rootSchema, pathSegments, optionErrors);
+      return optionErrors.length === 0;
+    });
+
+    if (!matches) {
+      errors.push({ path: pathSegments.join('.'), message: 'Value does not match anyOf schemas' });
+    }
+    return;
+  }
+
+  if (schema.enum) {
+    if (!schema.enum.includes(data)) {
+      errors.push({ path: pathSegments.join('.'), message: `Value must be one of ${schema.enum.join(', ')}` });
+      return;
+    }
+  }
+
+  if (schema.type) {
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+    const validType = types.some((type) => matchesType(type, data));
+    if (!validType) {
+      errors.push({ path: pathSegments.join('.'), message: `Expected type ${types.join(' or ')}` });
+      return;
+    }
+  }
+
+  if (schema.pattern && typeof data === 'string') {
+    const regex = new RegExp(schema.pattern);
+    if (!regex.test(data)) {
+      errors.push({ path: pathSegments.join('.'), message: `Value does not match pattern ${schema.pattern}` });
+    }
+  }
+
+  if (schema.type === 'object') {
+    if (!matchesType('object', data)) {
+      errors.push({ path: pathSegments.join('.'), message: 'Expected object' });
+      return;
+    }
+    const required = schema.required ?? [];
+    for (const key of required) {
+      if (!(key in data)) {
+        errors.push({ path: [...pathSegments, key].join('.'), message: 'Missing required property' });
+      }
+    }
+
+    const properties = schema.properties ?? {};
+    const additional = schema.additionalProperties;
+
+    if (schema.minProperties && Object.keys(data).length < schema.minProperties) {
+      errors.push({ path: pathSegments.join('.'), message: `Expected at least ${schema.minProperties} properties` });
+    }
+
+    for (const [key, value] of Object.entries(data)) {
+      const propertySchema = properties[key];
+      if (propertySchema) {
+        validateSchema(propertySchema, value, rootSchema, [...pathSegments, key], errors);
+      } else if (additional === false) {
+        errors.push({ path: [...pathSegments, key].join('.'), message: 'Unexpected property' });
+      } else if (typeof additional === 'object') {
+        validateSchema(additional, value, rootSchema, [...pathSegments, key], errors);
+      }
+    }
+  }
+
+  if (schema.type === 'array') {
+    if (!Array.isArray(data)) {
+      errors.push({ path: pathSegments.join('.'), message: 'Expected array' });
+      return;
+    }
+    if (schema.minItems && data.length < schema.minItems) {
+      errors.push({ path: pathSegments.join('.'), message: `Expected at least ${schema.minItems} items` });
+    }
+    const itemSchema = schema.items;
+    if (itemSchema) {
+      data.forEach((item, index) => {
+        validateSchema(itemSchema, item, rootSchema, [...pathSegments, String(index)], errors);
+      });
+    }
+  }
+};
+
+const validateWithSchema = (schema, data) => {
+  const errors = [];
+  validateSchema(schema, data, schema, ['root'], errors);
+  return errors;
+};
+
+const targets = [
+  {
+    name: 'categories',
+    schema: 'schemas/categories.schema.json',
+    data: 'data/categories.json'
+  },
+  {
+    name: 'filters',
+    schema: 'schemas/filters.schema.json',
+    data: 'data/filters.json'
+  },
+  {
+    name: 'vehicles',
+    schema: 'schemas/vehicles.schema.json',
+    data: 'data/vehicles/vehicles.json'
+  }
+];
+
+async function validateAll() {
+  let hasErrors = false;
+
+  for (const target of targets) {
+    try {
+      const [schema, data] = await Promise.all([readJson(target.schema), readJson(target.data)]);
+      const errors = validateWithSchema(schema, data);
+      if (errors.length === 0) {
+        console.log(`✅ ${target.name} valid`);
+      } else {
+        hasErrors = true;
+        console.error(`❌ ${target.name} invalid`);
+        for (const error of errors) {
+          console.error(`  • ${error.path}: ${error.message}`);
+        }
+      }
+    } catch (error) {
+      hasErrors = true;
+      console.error(`❌ Failed to validate ${target.name}`);
+      console.error(error);
+    }
+  }
+
+  if (hasErrors) {
+    process.exitCode = 1;
+  } else {
+    console.log('All JSON assets validated successfully.');
+  }
+}
+
+validateAll();

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,21 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './app/**/*.{ts,tsx,mdx}',
+    './docs/**/*.{md,mdx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          primary: '#0f172a',
+          accent: '#f97316'
+        }
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add structured vehicle listings dataset and surface featured entries on the home page
- upgrade category browsing to use client analytics, breadcrumbing, live filter state, and listing cards sourced from the dataset
- introduce a listing detail page with inspection summary, seller data, and related listings plus a seller workspace covering registration, listing creation, and inventory management flows

## Testing
- `node scripts/validate-json.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68cef6d45d80832ea8d118503ce4c827